### PR TITLE
v3.0.0: SkyPilot Spot campaigns over an S3 work queue

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,8 +42,8 @@ identifiers:
     type: doi
     value: "10.5281/zenodo.XXXXXXX"  # To be updated after Zenodo upload
 
-date-released: 2026-01-01
-version: "2.0.0"
+date-released: 2026-08-18
+version: "3.0.0"
 
 references:
   - authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,11 +37,6 @@ keywords:
   - aws
   - containerization
 
-identifiers:
-  - description: "Zenodo archive DOI (primary)"
-    type: doi
-    value: "10.5281/zenodo.XXXXXXX"  # To be updated after Zenodo upload
-
 date-released: 2026-08-18
 version: "3.0.0"
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ pixi run smoke-test
 | [docs/phasenet_v7_model_description.md](docs/phasenet_v7_model_description.md) | Model architecture & benchmarks |
 | [docs/smoke_test_workflow.md](docs/smoke_test_workflow.md) | Validation workflow |
 | [docs/rerun_2026/15_monitoring.md](docs/rerun_2026/15_monitoring.md) | Cost alerts and emergency stop |
+| [notebooks/5_submit_job_parquet.ipynb](notebooks/5_submit_job_parquet.ipynb) | Launch a Fargate campaign with Parquet output (no DocumentDB) |
+| [notebooks/6_check_parquet.ipynb](notebooks/6_check_parquet.ipynb) | Query the Parquet catalogue |
 | [reports/](reports/) | Rendered benchmark reports, published at [seisscoped.org/QuakeScope](https://seisscoped.org/QuakeScope/) |
 | [SECURITY_AUDIT.md](SECURITY_AUDIT.md) | Security assessment |
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Cloud-native Machine Learning workflow for earthquake event detection and phase picking
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)
 
 A cloud-native workflow for automated seismic phase picking and earthquake detection using deep learning, deployed on AWS with containerized models and managed infrastructure.
 
@@ -110,6 +109,21 @@ emergency-stop sequence are in
 - 🔍 **Monitored**: CloudWatch dashboards and SNS alerts for job tracking
 
 ## Architecture
+
+Two deployment paths are supported, and they differ in more than plumbing:
+
+| | v2 — AWS Batch on Fargate Spot | v3 — SkyPilot Spot + S3 queue |
+|---|---|---|
+| Proven at | the 2025 petabyte campaign | two shards end to end |
+| State | DocumentDB (VPC-bound) | S3 objects, no database |
+| Submission from | an EC2 controller inside the VPC | anywhere |
+| Notebooks | [3](notebooks/3_submit_job.ipynb), [4](notebooks/4_check_database.ipynb) | [5](notebooks/5_submit_job_parquet.ipynb), [6](notebooks/6_check_parquet.ipynb) |
+
+Both write picks as Parquet on S3. The diagram below is the v2 path; for v3 see
+[14_skypilot.md](docs/rerun_2026/14_skypilot.md), and
+[16_skypilot_vs_fargate.md](docs/rerun_2026/16_skypilot_vs_fargate.md) for the
+cost comparison.
+
 
 ```
 Continuous Waveforms (SCEDC/NCEDC S3)

--- a/docs/rerun_2026/14_skypilot.md
+++ b/docs/rerun_2026/14_skypilot.md
@@ -63,7 +63,13 @@ Three mechanisms, in order of who catches what:
 2. **SIGTERM release.** Preemption gives about two minutes' notice. The worker
    releases its in-flight claim and exits, so that shard is available again
    immediately rather than after the lease.
-3. **Lease expiry.** For a node killed outright with no warning, a claim older
+3. **Checkpointing.** Picks are buffered until the job ends, so without this a
+   preemption twelve hours into a shard discards twelve hours of work. The
+   worker flushes Parquet and records progress every `--checkpoint-every`
+   station-day-channels (default 40), and a resumed shard skips what is already
+   written. The order is fixed and matters: flush first, record second - the
+   reverse would let a resume skip station-days whose picks were never stored.
+4. **Lease expiry.** For a node killed outright with no warning, a claim older
    than `--lease-hours` (default 6) with no manifest is reclaimable. Set this
    above the longest expected shard runtime, or live shards will be stolen and
    done twice.

--- a/docs/rerun_2026/14_skypilot.md
+++ b/docs/rerun_2026/14_skypilot.md
@@ -1,0 +1,187 @@
+# 14 — Running a campaign on SkyPilot (v3)
+
+v3 replaces AWS Batch + Fargate Spot + DocumentDB with **SkyPilot managed jobs
+over an S3 work queue**. There is no job definition to register, no compute
+environment, no database, and no VPC to launch inside. Submission runs from a
+laptop.
+
+## Why managed jobs and not a cluster
+
+`sky launch` with `use_spot` gives you Spot instances but **no recovery** — when
+AWS reclaims the node, the cluster stays down. Only `sky jobs launch` puts the
+work under SkyPilot's jobs controller, which relaunches after a preemption.
+Since the whole point here is to run on Spot, campaigns use managed jobs.
+
+That makes preemption routine rather than exceptional, which is what the rest of
+the design is built around.
+
+## The three pieces
+
+| Piece | What it does | Where |
+|---|---|---|
+| `shard_planner` | Groups stations and days into shards, writes `shards.jsonl` | run once per campaign |
+| `worker` | Claims a shard, picks it, writes Parquet, writes a manifest | N loops × N nodes |
+| `s3_state` | Stations, claims, manifests, provenance — all on S3 | the former database |
+
+Grouping is unchanged from 2025: **40 stations × 20 days** per shard. At launch
+scale that is 64,240 shards over 51.2M station-days.
+
+## Running one
+
+```bash
+pixi install --environment deploy
+
+# 1. Plan the queue (once; it is immutable afterwards)
+pixi run -e deploy python -m sb_catalog.src.shard_planner \
+    --campaign s3://quakescope-picks-2026/scedc \
+    --stations s3://quakescope-picks-2026/stations.parquet \
+    --network CI --start 2018.001 --end 2020.366
+
+# 2. Launch the workers as a MANAGED job
+pixi run -e deploy sky jobs launch -n qs-scedc skypilot/campaign.yaml \
+    --env CAMPAIGN=s3://quakescope-picks-2026/scedc \
+    --env WEIGHT=jma_wc
+
+# 3. Watch
+pixi run -e deploy sky jobs queue
+pixi run -e deploy python -c "
+from sb_catalog.src.s3_state import S3CampaignState
+print(S3CampaignState('s3://quakescope-picks-2026/scedc').progress())"
+```
+
+Add `--dry-run` to the planner to see the shard count and station-day total
+without writing the queue.
+
+## How Spot preemption is survived
+
+Three mechanisms, in order of who catches what:
+
+1. **Atomic claims.** A worker takes a shard with an S3 conditional write
+   (`IfNoneMatch: "*"`), which fails if the key exists. Two workers can never
+   hold the same shard. Verified under 8 concurrent workers against 50 shards:
+   50 claims, 0 double-claims.
+2. **SIGTERM release.** Preemption gives about two minutes' notice. The worker
+   releases its in-flight claim and exits, so that shard is available again
+   immediately rather than after the lease.
+3. **Lease expiry.** For a node killed outright with no warning, a claim older
+   than `--lease-hours` (default 6) with no manifest is reclaimable. Set this
+   above the longest expected shard runtime, or live shards will be stolen and
+   done twice.
+
+A manifest is written **only after** the shard's Parquet is durable, so a
+manifest never exists for work whose picks were lost. Resume is therefore just:
+skip every shard that has one.
+
+Workers are stateless. Scale `num_nodes` up or down mid-campaign, relaunch after
+a preemption, or run a second job against the same queue — nothing needs
+cleaning up first.
+
+## Terminating when the campaign is done
+
+Managed jobs terminate their **worker** cluster when the job finishes. The
+**jobs controller does not stop itself**, and `sky down --all` does not
+terminate it either — it reports success and leaves an on-demand instance
+running. Observed directly: after cancelling every job and running
+`sky down --all`, an on-demand `m6i.xlarge` controller was still up at
+$0.192/hour.
+
+Fix it once, before launching, by copying
+[`skypilot/sky-config.yaml`](../../skypilot/sky-config.yaml) to
+`~/.sky/config.yaml`:
+
+```yaml
+jobs:
+  controller:
+    autostop:
+      down: true            # terminate; the default only *stops* it
+      idle_minutes: 15
+      wait_for: jobs_and_ssh
+```
+
+Controller settings are read **only** from `~/.sky/config.yaml` — a task or
+project YAML is ignored. `down: true` matters more than the timeout: the default
+leaves a stopped instance that still bills its EBS volume.
+
+Verify rather than trust it:
+
+```bash
+pixi run -e cloud watch      # queries EC2 directly
+```
+
+## Campaign layout on S3
+
+```
+s3://<bucket>/<campaign>/
+    stations.parquet          station metadata          (was: stations)
+    shards.jsonl              the work queue            (new)
+    claims/<shard_id>.json    who holds what            (new)
+    manifests/<shard_id>.json what finished             (was: picks_record)
+    runs/<run_id>.json        provenance                (was: sb_runs)
+    picks/network=/year=/month=/*.parquet
+```
+
+## The job runs in the container, not a fresh install
+
+`resources.image_id` points at `ghcr.io/seisscoped/quakescope`, the image GitHub
+Actions already builds on every push to `main`. It carries torch, SeisBench,
+pyarrow and the model weights, so a node has nothing to install and `setup` is
+just a readiness check.
+
+This is not a small saving. `setup` re-runs **on every Spot recovery**, not only
+at first launch, so anything expensive there is paid again at each preemption.
+Measured on this campaign: a `pixi install` in `setup` took ~4m40s per node,
+against a few seconds to pull the image. On a campaign sized for preemption that
+is the difference between recovery being cheap and recovery being the dominant
+cost.
+
+**Pin the short-SHA tag for a real campaign.** `:latest` moves when someone
+pushes to `main`, and a recovered node would then pull a different image than
+the one the campaign started with:
+
+```yaml
+image_id: docker:ghcr.io/seisscoped/quakescope:a1b2c3d
+```
+
+The code is pinned with it, at `/code/src`, which is why the template has no
+`workdir` and runs `python -m src.worker`. To test a branch before it is merged
+and built, add a `workdir` block and run `python -m sb_catalog.src.worker` from
+`~/sky_workdir` instead — the image still supplies the environment, so nothing
+is installed either way.
+
+## Sizing
+
+`num_nodes × PROCS` is the parallelism. The default 4 nodes × 8 procs = 32
+concurrent shards; a 32-vCPU instance leaves room for the picker's own threads
+inside each loop. Raise `num_nodes` for throughput — the queue does not care.
+
+Cost lever: the campaign is embarrassingly parallel and interruption-tolerant,
+so Spot is close to free money here. The `any_of` block prefers Spot and falls
+back to on-demand only when a region runs dry, which stops a campaign stalling
+outright.
+
+## What this replaces
+
+| v2 (Batch) | v3 (SkyPilot) |
+|---|---|
+| `job_definition_picking.yaml`, re-registered per campaign | `skypilot/campaign.yaml`, no registration |
+| `submit_helper.py` → `batch.submit_job` × 64,240 | `shard_planner` writes one queue file |
+| `retryStrategy: attempts 10` | claims + lease + jobs-controller recovery |
+| DocumentDB for stations/`picks_record`/`sb_runs` | S3 objects under the campaign prefix |
+| EC2 controller inside the DocumentDB VPC | any machine with AWS credentials |
+
+The Batch path still exists (`submit_helper.py`, the job definitions) for
+reproducing the 2025 campaign, but it is not the supported route in v3 and the
+DocumentDB collections it needs are no longer created by the picking path.
+
+## Caveats
+
+- **Association still needs a database.** `run_association` reads and writes
+  `picks`, `events` and assignments through the Mongo interface, and has no S3
+  equivalent yet. A v3 campaign is picking only — which matches the 2026 plan,
+  where the classifier is also out.
+- **Conditional writes are required.** The claim protocol needs an S3 endpoint
+  that honours `IfNoneMatch`. AWS S3 does; some S3-compatible stores do not, and
+  `s3_state` refuses to run rather than race silently.
+- **The queue is immutable.** Completed work is keyed on shard id, so extending
+  a campaign's date range means a new campaign prefix, not a rewritten
+  `shards.jsonl`.

--- a/docs/rerun_2026/16_skypilot_vs_fargate.md
+++ b/docs/rerun_2026/16_skypilot_vs_fargate.md
@@ -180,6 +180,13 @@ process sweep shows memory pressure.
 
 ## 6. Reading the output
 
+Two notebooks do all of this interactively:
+[`notebooks/5_submit_job_parquet.ipynb`](../../notebooks/5_submit_job_parquet.ipynb)
+launches a campaign on Fargate with no DocumentDB, and
+[`notebooks/6_check_parquet.ipynb`](../../notebooks/6_check_parquet.ipynb)
+queries the result. They are the Parquet counterparts of notebooks 3 and 4,
+which remain for the 2025 database path.
+
 ### 6a. The 2025 catalog, in DocumentDB
 
 ```python

--- a/docs/rerun_2026/16_skypilot_vs_fargate.md
+++ b/docs/rerun_2026/16_skypilot_vs_fargate.md
@@ -1,0 +1,301 @@
+# 16 — SkyPilot vs Fargate Spot, and the move to Parquet
+
+A cost and bottleneck comparison of the two ways to run a picking campaign, plus
+why the 2025 DocumentDB output became Parquet on S3 and how to read either.
+
+Measured on real shards, not modelled, unless a row says otherwise.
+
+---
+
+## 1. Where the time actually goes
+
+One station-day, `CI.CLC` and `CI.TOW2`, 2019 DOY 187–188, 8 vCPU Spot instance,
+one worker process, `worker --profile`:
+
+| stage | mainshock day | ordinary day | scales with |
+|---|--:|--:|---|
+| **amp.wood_anderson** | 25.5 s (47%) | 25.5 s (47%) | picks |
+| **model.classify** | 24.0 s (45%) | 22.2 s (38%) | samples |
+| amp.raw | 2.3 s (4%) | 2.3 s (4%) | picks |
+| s3.get | 1.2 s (2%) | 1.7 s (3%) | bytes |
+| mseed.parse | 0.3 s (0.5%) | 0.3 s (0.4%) | bytes |
+| s3.list | ~0 | ~0 | objects in prefix |
+| **parquet.encode + put** | **0.05 s (0.1%)** | **0.05 s (0.1%)** | rows |
+| s3.head | ~0 | ~0 | objects |
+| *unaccounted* | 0.4 s (0.7%) | | |
+
+Three conclusions, and they drive everything below.
+
+**The workload is CPU-bound, not I/O-bound.** Every S3 and parsing stage
+together is under 4%, at 31–47 MB/s. This is the single most useful result: it
+means **cross-region reads are not a cost problem**, so compute does not have to
+sit in the same region as the data. That frees the campaign to run in us-east-2,
+where the Fargate Spot quota already is.
+
+**Writing Parquet is free — 0.1% of runtime.** Whatever else is true about the
+storage change, it did not cost throughput.
+
+**Amplitude extraction is the largest stage, larger than inference.** It is also
+the thing added since 2025. This is where the remaining money is, and §5 covers
+what has been done and what has not.
+
+---
+
+## 2. Platform comparison
+
+Matched as closely as the two platforms allow: same container image, same code,
+8 vCPU / 16 GB, one worker process, same shard, same S3 output.
+
+| | SkyPilot (EC2 Spot) | AWS Batch (Fargate Spot) |
+|---|---|---|
+| Cold start, measured | ~2–4 min (instance provision) | **61 s** median, 59–72 s (n=3) |
+| Spot quota, us-east-2 | **256 vCPU** (`L-34B43A08`) | **12,000 vCPU** (`L-36FBB829`) |
+| Spot quota, us-west-2 | 656 vCPU | — |
+| Price, measured | c7g.16xlarge **$0.0133/vCPU-hr** | — |
+| Price, list | m6i.xlarge $0.0224/vCPU-hr | on-demand **$0.04937/vCPU-hr** (8 vCPU/16 GB) |
+| Price, Spot estimate | measured above | ~**$0.0148/vCPU-hr** at the usual ~70% discount |
+| Preemption recovery | jobs controller relaunches | Batch `retryStrategy` re-queues |
+| Idle cost | **jobs controller is on-demand and persists** | none between jobs |
+| Instance choice | any type, incl. Graviton | vCPU/memory only |
+
+**Price is close to a wash.** EC2 Spot on Graviton is measurably $0.0133/vCPU-hr;
+Fargate Spot is *estimated* at $0.0148 because AWS does not publish the Spot rate
+through the pricing API, and Cost Explorer is blocked on this account by an
+organisation SCP (`p-q1ngvul9`) so the 2025 actuals could not be recovered
+either. **Treat the Fargate figure as unverified.** Reaching the cheaper EC2
+number also requires an arm64 image, which does not exist yet.
+
+**Quota is not a wash.** 12,000 vs 256 vCPU in us-east-2 is a 47× difference in
+achievable parallelism, and it is already granted. At 256 vCPU a full campaign
+takes months; the EC2 route needs a quota increase before it is viable there at
+all.
+
+**Two operational differences that matter more than the price:**
+
+- The SkyPilot **jobs controller is on-demand and does not stop itself**. It
+  survives `sky down --all`, which reports success and leaves it running — see
+  [15_monitoring.md](15_monitoring.md). On a Spot campaign it is the most
+  expensive thing to forget.
+- Fargate has **no instance to leak**: when a job ends the task is gone.
+
+**Recommendation, pending the outstanding measurement:** Fargate Spot in
+us-east-2, on the quota you already hold, unless the EC2 quota increase lands
+*and* an arm64 image makes Graviton reachable. The deciding factor is not price
+per vCPU-hour but whether 12,000 vCPU of headroom is worth more than a ~10%
+hourly saving that depends on two prerequisites.
+
+### What is not yet measured
+
+A true head-to-head is blocked: the published image is built from `main`, so it
+still crashes on `EARTHSCOPE_S3_ACCESS_POINT` at import and has no `pyarrow`.
+Fargate probes exited 1 for exactly that reason. Once PR #27 merges and Actions
+rebuilds, `quakescope_v3_bench` (already registered) runs the identical worker
+via `python -m src.picker work`, and the same shard can be timed on both.
+
+---
+
+## 3. Scalability
+
+Per-band-day cost is **~54 s** on 8 vCPU with one process, after the amplitude
+work in §5. The campaign is 52.1M station-days
+([12_output_storage.md](12_output_storage.md) §1, operating-window aware).
+
+Two numbers are still unmeasured and together swing the total by ~4×:
+
+- **processes per vCPU** — every measurement so far used one process on an
+  8 vCPU box, so most of the machine was idle. `worker --procs` exists; the
+  sweep has not been run.
+- **bands per station** — the picker currently processes every band a station
+  has, measured at **2.83×** on SCEDC, including `LH` at 1 Hz which cannot be
+  picked at all. One-band-per-station is agreed but not implemented.
+
+Until both are measured, any total campaign cost is a guess with a 4× error bar,
+and this document deliberately does not state one.
+
+**Wall-clock is quota-bound, not throughput-bound.** At 12,000 vCPU the arithmetic
+is comfortable; at 256 it is not.
+
+---
+
+## 4. Why DocumentDB became Parquet on S3
+
+| | DocumentDB (2025) | Parquet on S3 (2026) |
+|---|--:|--:|
+| Bytes per pick | 148 (BSON), ~228 with indexes | **35** |
+| At 88B picks | 13.1 TB, ~20.2 TB with indexes | **3.1 TB** |
+| Storage cost | ~$465/month + cluster instance-hours | **~$71/month**, nothing running |
+| Write cost in the pipeline | per-station-day `insert_many` | **0.1% of runtime** (measured) |
+| Between campaigns | cluster must stay up | nothing to run |
+| Requires a VPC | yes — submission had to run inside it | **no** |
+
+Measurements in [12_output_storage.md](12_output_storage.md) §2.
+
+The change is a win on every axis measured: **6.5× less storage**, the cluster
+and its VPC constraint disappear, and the write path costs 0.1% of a station-day.
+Dictionary encoding is why — `tid`, `cha`, `pha` and `rid` repeat down a column
+and compress to almost nothing, while BSON repeats every field *name* in every
+document.
+
+**What did not move.** Station metadata and resume state are small, need point
+lookups, and are what a database is good at. In v3 they became S3 objects too
+(`stations.parquet`, `complete/`, `manifests/`) — see
+[14_skypilot.md](14_skypilot.md) — but that is a consequence of dropping the
+database entirely, not of the Parquet decision.
+
+**The one cost.** Parquet buffers a partition in memory until
+`flush_threshold` (4M rows, ~800 MB resident per partition per process). That is
+a RAM floor the streaming database writer did not have, and it will not fit
+alongside one process per vCPU on a memory-light instance. Lower it if the
+process sweep shows memory pressure.
+
+---
+
+## 5. What has been optimised, and what remains
+
+**Done, and verified:**
+
+- **Deconvolution hoisted** out of the per-pick loop — was one
+  `remove_response` per pick, ~6,700 per busy station-day. Now once per station.
+  5.3× faster on that stage, and *more correct*: the old 33 s window was
+  ill-conditioned, returning 0.170 where every longer window converges on
+  0.00045. Roughly 5% of picks were affected.
+- **Per-pick path moved to numpy** — obspy `Stream.slice()` per pick over an
+  8.6M-sample trace, plus a `select()` scan per trace per pick. `amp.raw` went
+  5.7 s → 2.3 s.
+- **joblib removed** — `Parallel(n_jobs=-1)` was nested *inside* each worker
+  process, oversubscribing every core.
+
+**Remaining, in order of expected value:**
+
+1. **`amp.wood_anderson` is still 47% of runtime**, and the per-pick loop is no
+   longer the cost — the deconvolution of a day-long trace is. This is the
+   biggest single lever left.
+2. **Process sweep** (`--procs` × `OMP_NUM_THREADS`) — up to 4×, unmeasured.
+3. **One band per station** — 2.83× on the California campaigns.
+4. **arm64 image** — 1.68× on price, and the only route to the cheapest EC2 tier.
+5. **Restore the operating-window filter** the v3 planner lost; v2 applied
+   `filter_station_by_start_end_date` (`utils.py:183`).
+
+---
+
+## 6. Reading the output
+
+### 6a. The 2025 catalog, in DocumentDB
+
+```python
+import pymongo, datetime
+
+client = pymongo.MongoClient(
+    DOCDB_ENDPOINT_URI,                      # from sb_catalog/src/parameters.py
+    tls=True, tlsCAFile="global-bundle.pem", # AWS RDS trust store
+    retryWrites=False,                       # DocumentDB does not support it
+)
+db = client["quakescope_2025"]
+
+# Picks for one station in a time range. Indexed on (peak, tid).
+rows = db["picks"].find({
+    "tid": "CI.CLC.",
+    "peak": {"$gte": datetime.datetime(2019, 7, 6),
+             "$lt":  datetime.datetime(2019, 7, 7)},
+})
+```
+
+Only reachable from **inside the DocumentDB VPC** — that constraint is a large
+part of why v3 left. Collections: `picks`, `classifies`, `picks_record`,
+`stations`, `sb_runs`.
+
+### 6b. The 2026 catalog, in Parquet
+
+Layout:
+
+```
+s3://<bucket>/<campaign>/
+    picks/network=CI/year=2019/month=07/<shard_id>.parquet
+    manifests/<shard_id>.json      what each job wrote, including object keys
+    complete/<shard_id>.json       queue state
+    shards.jsonl                   the immutable work queue
+    stations.parquet               station metadata
+```
+
+**Whole-dataset query, letting the engine prune partitions.** Simplest, and
+correct for analysis:
+
+```python
+import duckdb
+con = duckdb.connect()
+con.execute("INSTALL httpfs; LOAD httpfs;")
+con.execute("""
+    SELECT tid, pha, peak, conf, amp
+    FROM read_parquet('s3://bucket/campaign/picks/**/*.parquet',
+                      hive_partitioning = true)
+    WHERE network = 'CI' AND year = 2019 AND month = 7
+      AND tid = 'CI.CLC.'
+      AND conf >= 0.5
+    ORDER BY peak
+""").df()
+```
+
+`network`, `year` and `month` are **partition keys**, so those predicates skip
+whole prefixes rather than reading them. `tid` and `conf` are pushed to Parquet
+row-group statistics. Same in pyarrow:
+
+```python
+import pyarrow.dataset as ds
+dataset = ds.dataset("s3://bucket/campaign/picks/", format="parquet",
+                     partitioning="hive")
+table = dataset.to_table(
+    filter=(ds.field("network") == "CI") & (ds.field("year") == 2019)
+           & (ds.field("tid") == "CI.CLC."),
+    columns=["tid", "pha", "peak", "conf", "amp"],
+)
+```
+
+### 6c. Reading without a single LIST
+
+Partition pruning still **lists** the prefixes it keeps. To avoid listing
+entirely, use the manifests as the index — they record the exact object keys a
+job wrote:
+
+```python
+import json, s3fs, pyarrow.parquet as pq
+
+fs = s3fs.S3FileSystem()
+root = "bucket/campaign"
+
+# 1. One GET: the work queue tells you which shard covers which stations/days.
+shards = [json.loads(l) for l in
+          fs.cat(f"{root}/shards.jsonl").decode().splitlines() if l.strip()]
+
+want, day = "CI.CLC.", "2019.187"
+hits = [s for s in shards
+        if want in s["stations"] and s["start"] <= day < s["end"]]
+
+# 2. One GET per shard: the manifest names the objects that shard produced.
+for s in hits:
+    manifest = json.loads(fs.cat(f"{root}/manifests/{s['shard_id']}.json"))
+    for f in manifest["files"]:
+        if f["kind"] != "picks":
+            continue
+        # 3. One GET per file. No LIST anywhere in this path.
+        table = pq.read_table(f["path"], filesystem=fs,
+                              columns=["tid", "pha", "peak", "conf", "amp"])
+        print(f["path"], table.num_rows)
+```
+
+**Why this works.** `shard_id` is content-derived —
+`{start:%Y%j}-{end:%Y%j}-{sha1(stations|start|end)[:12]}` — so it is stable
+across re-planning, and the manifest records every key including the `-001`
+sequence suffixes a large partition produces. Neither is reconstructible from
+the shard definition alone, which is why the manifest is the index rather than a
+naming convention.
+
+**Which to use.** 6b for analysis, where the engine's pruning is faster to write
+and fast enough. 6c for a service or a tight loop, where LIST latency and request
+cost matter and the access pattern is known in advance.
+
+### 6d. Provenance
+
+Every pick carries `rid`, the run id, which resolves through
+`runs/<run_id>.json` to the model, weight and thresholds that produced it. That
+is how picks from different weights stay separable inside one campaign — the
+same job `sb_runs` did in 2025.

--- a/docs/rerun_2026/README.md
+++ b/docs/rerun_2026/README.md
@@ -143,6 +143,11 @@ flowchart LR
 > against it. Note the picking job definition **no longer hardcodes**
 > `--classifier` and must be re-registered.
 
+> **v3 runs on SkyPilot, not Batch.** Fargate Spot, the job definitions and
+> DocumentDB are replaced by SkyPilot managed jobs over an S3 work queue —
+> see [14_skypilot.md](14_skypilot.md). Phases C and D below (DocumentDB,
+> Batch compute environment) do not apply to a v3 campaign.
+
 > **Amplitudes changed convention.** The Wood-Anderson constants were a mix of
 > the Richter and IASPEI standards and are now IASPEI throughout, which shifts
 > ML by a near-uniform +0.033 relative to the 2025 catalog. See

--- a/notebooks/5_submit_job_parquet.ipynb
+++ b/notebooks/5_submit_job_parquet.ipynb
@@ -1,0 +1,382 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stage 5: submit a Parquet campaign to Fargate\n",
+    "\n",
+    "The Parquet equivalent of [3_submit_job.ipynb](./3_submit_job.ipynb). Same compute — AWS Batch on Fargate Spot, the infrastructure that ran the 2025 campaign — but **no DocumentDB anywhere**.\n",
+    "\n",
+    "### What changes\n",
+    "\n",
+    "| | 3_submit_job (2025) | this notebook |\n",
+    "|---|---|---|\n",
+    "| Work planning | `submit_helper` reads stations from DocumentDB | `shard_planner` writes an immutable queue to S3 |\n",
+    "| One Batch job = | one 40x20 shard | one worker that drains many shards |\n",
+    "| Picks land in | `picks` collection | Parquet on S3 |\n",
+    "| Resume state | `picks_record` collection | `complete/` + `progress/` on S3 |\n",
+    "| Needs a VPC | yes — submission must run inside it | no, runs from anywhere |\n",
+    "| Preemption costs | the whole 800-station-day job | 40 station-day-channels |\n",
+    "\n",
+    "### ⚠️ Before running\n",
+    "\n",
+    "1. **The image must contain the v3 code.** `ghcr.io/seisscoped/quakescope:latest` is built from `main`; until the v3 PRs merge it has no `pyarrow` and crashes on import, and every task will fail. Check with the cell in §1.\n",
+    "2. **Job queue and compute environment must exist** — see [1_prepare_compute_env.ipynb](./1_prepare_compute_env.ipynb). The 2025 ones (`niyiyu_earthscope`, Fargate Spot, maxvCpus 4000) are reusable.\n",
+    "3. **Cost alerts on** — see [15_monitoring.md](../docs/rerun_2026/15_monitoring.md). A campaign is a multi-day, five-figure action.\n",
+    "4. **Run the smoke test in §5 first.** Not optional: it is how you find out the image, credentials and output prefix all work before committing the full queue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os, json, glob\n",
+    "\n",
+    "sys.path.append(\"..\")\n",
+    "\n",
+    "import boto3\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sb_catalog.src.s3_state import S3CampaignState\n",
+    "from sb_catalog.src.shard_planner import plan, parse_year_day\n",
+    "\n",
+    "REGION = \"us-east-2\"          # where the Fargate Spot quota is\n",
+    "JOB_QUEUE = \"\"                # e.g. niyiyu_earthscope_missing_station\n",
+    "JOB_DEFINITION = \"\"           # registered in section 4\n",
+    "IMAGE = \"ghcr.io/seisscoped/quakescope:latest\"   # PIN A SHORT-SHA FOR A REAL RUN\n",
+    "\n",
+    "CAMPAIGN = \"s3://<bucket>/<campaign>\"            # everything lives under here\n",
+    "WEIGHT = \"jma_wc\"\n",
+    "\n",
+    "batch = boto3.client(\"batch\", region_name=REGION)\n",
+    "assert CAMPAIGN.startswith(\"s3://\") and \"<bucket>\" not in CAMPAIGN, \"set CAMPAIGN\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Check the image can actually run a Parquet job\n",
+    "\n",
+    "This is the failure that wasted a smoke test: the published image imports\n",
+    "`EARTHSCOPE_S3_ACCESS_POINT` unconditionally and has no `pyarrow`, so tasks\n",
+    "exit 1 within seconds and Batch reports them as application failures.\n",
+    "\n",
+    "Submits one throwaway task that only checks the imports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "probe = batch.register_job_definition(\n",
+    "    jobDefinitionName=\"quakescope_image_probe\",\n",
+    "    type=\"container\",\n",
+    "    platformCapabilities=[\"FARGATE\"],\n",
+    "    containerProperties={\n",
+    "        \"image\": IMAGE,\n",
+    "        # `work --help` reaches the v3 worker through the fixed ENTRYPOINT.\n",
+    "        # It fails on an image that predates the v3 code, which is the point.\n",
+    "        \"command\": [\"work\", \"--help\"],\n",
+    "        \"jobRoleArn\": f\"arn:aws:iam::{boto3.client('sts').get_caller_identity()['Account']}:role/SeisBenchBatchRole\",\n",
+    "        \"executionRoleArn\": f\"arn:aws:iam::{boto3.client('sts').get_caller_identity()['Account']}:role/SeisBenchBatchRole\",\n",
+    "        \"resourceRequirements\": [\n",
+    "            {\"type\": \"VCPU\", \"value\": \"1\"},\n",
+    "            {\"type\": \"MEMORY\", \"value\": \"2048\"},\n",
+    "        ],\n",
+    "        \"networkConfiguration\": {\"assignPublicIp\": \"ENABLED\"},\n",
+    "        \"runtimePlatform\": {\"operatingSystemFamily\": \"LINUX\", \"cpuArchitecture\": \"X86_64\"},\n",
+    "    },\n",
+    "    retryStrategy={\"attempts\": 1},\n",
+    "    timeout={\"attemptDurationSeconds\": 600},\n",
+    ")\n",
+    "job = batch.submit_job(jobName=\"image-probe\", jobQueue=JOB_QUEUE,\n",
+    "                       jobDefinition=probe[\"jobDefinitionName\"])\n",
+    "print(\"probe job:\", job[\"jobId\"])\n",
+    "print(\"SUCCEEDED = the image has the v3 code. FAILED = merge the v3 PRs and let\")\n",
+    "print(\"Actions rebuild, then re-run this cell.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "while True:\n",
+    "    d = batch.describe_jobs(jobs=[job[\"jobId\"]])[\"jobs\"][0]\n",
+    "    if d[\"status\"] in (\"SUCCEEDED\", \"FAILED\"):\n",
+    "        break\n",
+    "    print(d[\"status\"], end=\"\\r\")\n",
+    "    time.sleep(10)\n",
+    "print(\"probe:\", d[\"status\"], d.get(\"statusReason\", \"\"))\n",
+    "assert d[\"status\"] == \"SUCCEEDED\", \"image cannot run the v3 worker - stop here\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Station metadata to S3\n",
+    "\n",
+    "Replaces [2_prepare_station_metadata.ipynb](./2_prepare_station_metadata.ipynb),\n",
+    "which wrote the `stations` collection. Same source files, same `channels`\n",
+    "convention (two-character band codes), written to `stations.parquet` instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames = []\n",
+    "for netfile in sorted(glob.glob(\"../networks/*.zip\")):\n",
+    "    stations = pd.read_csv(netfile)\n",
+    "    for i, s in stations.iterrows():\n",
+    "        cha = stations.loc[i, \"channels\"]\n",
+    "        stations.loc[i, \"channels\"] = \",\".join(sorted(set(c[:2] for c in cha.split(\",\"))))\n",
+    "    stations[\"location_code\"] = stations.apply(lambda s: s.id.split(\".\")[-1], axis=1)\n",
+    "    frames.append(stations)\n",
+    "\n",
+    "stations = pd.concat(frames, ignore_index=True)\n",
+    "print(f\"{len(stations):,} stations across {stations.network_code.nunique()} networks\")\n",
+    "\n",
+    "state = S3CampaignState(CAMPAIGN)\n",
+    "state.write_stations(stations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Plan the queue\n",
+    "\n",
+    "Same grouping as 2025 — 40 stations x 20 days — but written once as an\n",
+    "immutable `shards.jsonl` instead of becoming tens of thousands of\n",
+    "`submit_job` calls.\n",
+    "\n",
+    "**The queue is immutable.** Completed work is keyed on shard id, so extending a\n",
+    "campaign's date range means a new campaign prefix, not a rewritten queue.\n",
+    "Check the plan before writing it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NETWORK = \"CI\"                     # comma separated, or None with EXTENT\n",
+    "START, END = \"2019.001\", \"2019.031\"\n",
+    "\n",
+    "sel = state.get_stations(network=NETWORK)\n",
+    "shards = plan(sel, parse_year_day(START), parse_year_day(END))\n",
+    "\n",
+    "station_days = sum(s[\"n_station_days\"] for s in shards)\n",
+    "print(f\"{len(sel):,} stations -> {len(shards):,} shards, {station_days:,} station-days\")\n",
+    "print(f\"at ~54 s per band-day, roughly {station_days * 54 / 3600:,.0f} vCPU-hours of work\")\n",
+    "print(\"\\nfirst shard:\", json.dumps(shards[0], indent=2)[:300])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Writing the queue. Refuses to overwrite an existing one.\n",
+    "state.write_shards(shards)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Register the worker job definition\n",
+    "\n",
+    "One difference from 2025 worth understanding: a job here is **a worker, not a\n",
+    "shard**. It claims shards from the queue until they run out, so you choose how\n",
+    "many workers to run rather than submitting one job per unit of work.\n",
+    "\n",
+    "`work` reaches the v3 worker through the image's fixed `ENTRYPOINT`\n",
+    "(`python -m src.picker`), which Batch cannot override."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "account = boto3.client(\"sts\").get_caller_identity()[\"Account\"]\n",
+    "role = f\"arn:aws:iam::{account}:role/SeisBenchBatchRole\"\n",
+    "\n",
+    "jd = batch.register_job_definition(\n",
+    "    jobDefinitionName=\"quakescope_v3_worker\",\n",
+    "    type=\"container\",\n",
+    "    platformCapabilities=[\"FARGATE\"],\n",
+    "    parameters={\"campaign\": CAMPAIGN, \"weight\": WEIGHT, \"procs\": \"4\"},\n",
+    "    containerProperties={\n",
+    "        \"image\": IMAGE,\n",
+    "        \"command\": [\n",
+    "            \"work\",\n",
+    "            \"--campaign\", \"Ref::campaign\",\n",
+    "            \"--weight\", \"Ref::weight\",\n",
+    "            \"--procs\", \"Ref::procs\",\n",
+    "        ],\n",
+    "        \"jobRoleArn\": role,          # needs write access to the campaign prefix\n",
+    "        \"executionRoleArn\": role,\n",
+    "        \"resourceRequirements\": [\n",
+    "            {\"type\": \"VCPU\", \"value\": \"8\"},\n",
+    "            {\"type\": \"MEMORY\", \"value\": \"16384\"},\n",
+    "        ],\n",
+    "        \"networkConfiguration\": {\"assignPublicIp\": \"ENABLED\"},\n",
+    "        \"runtimePlatform\": {\"operatingSystemFamily\": \"LINUX\", \"cpuArchitecture\": \"X86_64\"},\n",
+    "        \"environment\": [\n",
+    "            # Empty is correct for SCEDC/NCEDC. Set both for the EarthScope archive.\n",
+    "            {\"name\": \"EARTHSCOPE_S3_ACCESS_POINT\", \"value\": \"\"},\n",
+    "            {\"name\": \"ES_OAUTH2__REFRESH_TOKEN\", \"value\": \"\"},\n",
+    "        ],\n",
+    "    },\n",
+    "    # A preempted worker is replaced; its shard returns to the queue and resumes\n",
+    "    # from its last checkpoint, so retries are cheap and idempotent.\n",
+    "    retryStrategy={\"attempts\": 10,\n",
+    "                   \"evaluateOnExit\": [\n",
+    "                       {\"action\": \"RETRY\", \"onStatusReason\": \"Your Spot Task was interrupted.\"},\n",
+    "                       {\"action\": \"EXIT\", \"onReason\": \"*\"}]},\n",
+    "    timeout={\"attemptDurationSeconds\": 86400},\n",
+    ")\n",
+    "JOB_DEFINITION = jd[\"jobDefinitionName\"]\n",
+    "print(\"registered\", JOB_DEFINITION, \"revision\", jd[\"revision\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Smoke test — one worker, a few shards\n",
+    "\n",
+    "Do not skip this. It is the cheapest way to find out that the output prefix is\n",
+    "unwritable, the weight name is wrong, or the archive needs credentials — all of\n",
+    "which otherwise surface as thousands of failed tasks.\n",
+    "\n",
+    "`--max-shards` stops the worker after a few, leaving the rest of the queue\n",
+    "untouched."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "smoke = batch.submit_job(\n",
+    "    jobName=\"qs-smoke\",\n",
+    "    jobQueue=JOB_QUEUE,\n",
+    "    jobDefinition=JOB_DEFINITION,\n",
+    "    parameters={\"campaign\": CAMPAIGN, \"weight\": WEIGHT, \"procs\": \"1\"},\n",
+    "    containerOverrides={\"command\": [\n",
+    "        \"work\", \"--campaign\", CAMPAIGN, \"--weight\", WEIGHT,\n",
+    "        \"--procs\", \"1\", \"--max-shards\", \"2\", \"--profile\",\n",
+    "    ]},\n",
+    ")\n",
+    "print(\"smoke job:\", smoke[\"jobId\"])\n",
+    "print(\"check progress with the cell below, and the picks in 6_check_parquet.ipynb\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(state.progress())\n",
+    "d = batch.describe_jobs(jobs=[smoke[\"jobId\"]])[\"jobs\"][0]\n",
+    "print(d[\"status\"], d.get(\"statusReason\", \"\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Launch the campaign\n",
+    "\n",
+    "Only after the smoke test has produced picks you have looked at.\n",
+    "\n",
+    "**How many workers?** `N_WORKERS x procs` is the parallelism, and\n",
+    "`N_WORKERS x vCPU` must stay inside both the Fargate Spot vCPU quota and the\n",
+    "compute environment's `maxvCpus` — the smaller of the two wins, and the\n",
+    "compute environment is usually it.\n",
+    "\n",
+    "Workers are stateless and idempotent: submit more at any time, and a preempted\n",
+    "one is replaced without anything to clean up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_WORKERS = 20          # x 8 vCPU = 160 vCPU\n",
+    "PROCS = \"4\"\n",
+    "\n",
+    "ce = batch.describe_job_queues(jobQueues=[JOB_QUEUE])[\"jobQueues\"][0][\n",
+    "    \"computeEnvironmentOrder\"][0][\"computeEnvironment\"]\n",
+    "cap = batch.describe_compute_environments(computeEnvironments=[ce])[\n",
+    "    \"computeEnvironments\"][0][\"computeResources\"][\"maxvCpus\"]\n",
+    "asked = N_WORKERS * 8\n",
+    "print(f\"requesting {asked} vCPU against a compute environment cap of {cap}\")\n",
+    "assert asked <= cap, f\"raise maxvCpus on {ce} or lower N_WORKERS\"\n",
+    "\n",
+    "ids = []\n",
+    "for i in range(N_WORKERS):\n",
+    "    r = batch.submit_job(\n",
+    "        jobName=f\"qs-worker-{i:03d}\",\n",
+    "        jobQueue=JOB_QUEUE,\n",
+    "        jobDefinition=JOB_DEFINITION,\n",
+    "        parameters={\"campaign\": CAMPAIGN, \"weight\": WEIGHT, \"procs\": PROCS},\n",
+    "    )\n",
+    "    ids.append(r[\"jobId\"])\n",
+    "print(f\"submitted {len(ids)} workers\")\n",
+    "json.dump(ids, open(\"submitted_workers.json\", \"w\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Stopping\n",
+    "\n",
+    "Cancelling a worker does not lose work: its shard returns to the queue and\n",
+    "resumes from its last checkpoint. There is no instance to terminate — Fargate\n",
+    "tasks disappear with the job, which is one of the reasons to prefer it here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for jid in json.load(open(\"submitted_workers.json\")):\n",
+    "#     batch.cancel_job(jobId=jid, reason=\"operator stop\")\n",
+    "# print(\"cancelled; re-submit section 6 to resume where the queue left off\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.10"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/6_check_parquet.ipynb
+++ b/notebooks/6_check_parquet.ipynb
@@ -1,0 +1,334 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stage 6: check a Parquet campaign\n",
+    "\n",
+    "The Parquet equivalent of [4_check_database.ipynb](./4_check_database.ipynb).\n",
+    "Everything that was a DocumentDB collection is now an object on S3:\n",
+    "\n",
+    "| 4_check_database | here |\n",
+    "|---|---|\n",
+    "| `stations` collection | `stations.parquet` |\n",
+    "| `picks` collection | `picks/network=/year=/month=/*.parquet` |\n",
+    "| `picks_record` collection | `complete/` and `progress/` |\n",
+    "| `sb_runs` collection | `runs/<run_id>.json` |\n",
+    "| — | `shards.jsonl`, the immutable work queue |\n",
+    "| — | `manifests/<job>.json`, what each job wrote |\n",
+    "\n",
+    "Runs from anywhere — no VPC, no endpoint, no cluster to keep alive.\n",
+    "\n",
+    "Three ways to read picks are shown, in increasing order of specificity:\n",
+    "§4 whole-dataset queries, §5 a single station, §6 a LIST-free path for services."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, json\n",
+    "\n",
+    "sys.path.append(\"..\")\n",
+    "\n",
+    "import pandas as pd\n",
+    "import s3fs\n",
+    "\n",
+    "from sb_catalog.src.s3_state import S3CampaignState\n",
+    "\n",
+    "CAMPAIGN = \"s3://<bucket>/<campaign>\"\n",
+    "\n",
+    "state = S3CampaignState(CAMPAIGN)\n",
+    "fs = s3fs.S3FileSystem()\n",
+    "root = CAMPAIGN[len(\"s3://\"):]\n",
+    "assert \"<bucket>\" not in CAMPAIGN, \"set CAMPAIGN\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Campaign progress\n",
+    "\n",
+    "The equivalent of counting documents in `picks_record`, but it also tells you\n",
+    "how much work is left — which the collection could not.\n",
+    "\n",
+    "- **complete** — shards finished, with their Parquet durable\n",
+    "- **in_flight** — claimed by a live worker, or abandoned and awaiting lease expiry\n",
+    "- **remaining** — not yet done"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = state.progress()\n",
+    "print(p)\n",
+    "if p[\"total\"]:\n",
+    "    print(f\"\\n{100 * p['complete'] / p['total']:.1f}% complete\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Stations\n",
+    "\n",
+    "Was `sbc.get_stations()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stations = state.get_stations()\n",
+    "print(f\"{len(stations):,} stations, {stations.network_code.nunique()} networks\")\n",
+    "stations.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. What each job produced\n",
+    "\n",
+    "The manifests are the audit trail: which station-days a job claimed, how many\n",
+    "picks each produced, and the exact objects written. This has no DocumentDB\n",
+    "equivalent — in 2025 you inferred it by counting rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manifests = fs.glob(f\"{root}/manifests/*.json\")\n",
+    "print(f\"{len(manifests)} job manifests\")\n",
+    "\n",
+    "rows = []\n",
+    "for m in manifests:\n",
+    "    d = json.loads(fs.cat(m))\n",
+    "    rows.append({\"job\": d[\"job_id\"], \"picks\": d[\"n_picks\"],\n",
+    "                 \"station_days\": d[\"station_days\"],\n",
+    "                 \"files\": len(d.get(\"files\", [])), \"written\": d[\"written_at\"]})\n",
+    "jobs = pd.DataFrame(rows).sort_values(\"picks\", ascending=False)\n",
+    "print(f\"total picks across all jobs: {jobs.picks.sum():,}\")\n",
+    "jobs.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Query the picks\n",
+    "\n",
+    "The everyday path. `network`, `year` and `month` are **partition keys**, so\n",
+    "predicates on them skip whole prefixes rather than reading them; `tid` and\n",
+    "`conf` are pushed down to row-group statistics.\n",
+    "\n",
+    "DuckDB is usually the least friction. pyarrow does the same thing if you would\n",
+    "rather stay in Arrow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "\n",
+    "con = duckdb.connect()\n",
+    "con.execute(\"INSTALL httpfs; LOAD httpfs;\")\n",
+    "con.execute(\"SET s3_region='us-west-2';\")   # region of the OUTPUT bucket\n",
+    "\n",
+    "con.execute(f\"\"\"\n",
+    "    SELECT network, year, month, pha, count(*) AS picks,\n",
+    "           round(avg(conf), 3) AS mean_conf\n",
+    "    FROM read_parquet('{CAMPAIGN}/picks/**/*.parquet', hive_partitioning = true)\n",
+    "    GROUP BY 1, 2, 3, 4\n",
+    "    ORDER BY picks DESC\n",
+    "    LIMIT 20\n",
+    "\"\"\").df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The same, in pyarrow.\n",
+    "import pyarrow.dataset as ds\n",
+    "\n",
+    "dataset = ds.dataset(f\"{root}/picks/\", filesystem=fs,\n",
+    "                     format=\"parquet\", partitioning=\"hive\")\n",
+    "print(dataset.schema)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Picks for one station\n",
+    "\n",
+    "The query 4_check_database did with `{\"tid\": ..., \"peak\": {...}}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "STATION = \"CI.CLC.\"\n",
+    "YEAR, MONTH = 2019, 7\n",
+    "\n",
+    "picks = con.execute(f\"\"\"\n",
+    "    SELECT tid, cha, pha, peak, conf, amp, amp_raw, rid\n",
+    "    FROM read_parquet('{CAMPAIGN}/picks/**/*.parquet', hive_partitioning = true)\n",
+    "    WHERE network = '{STATION.split('.')[0]}'\n",
+    "      AND year = {YEAR} AND month = {MONTH}\n",
+    "      AND tid = '{STATION}'\n",
+    "    ORDER BY peak\n",
+    "\"\"\").df()\n",
+    "print(f\"{len(picks):,} picks\")\n",
+    "print(picks.pha.value_counts().to_dict())\n",
+    "picks.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# amp is Wood-Anderson displacement (metres); amp_raw is high-passed counts.\n",
+    "# NaN amp is expected and honest: a pick whose window fell inside a taper is\n",
+    "# not measurable, and reporting the suppressed value would be wrong rather\n",
+    "# than merely imprecise. See docs/amplitude_conventions.md.\n",
+    "print(f\"amp set on {picks.amp.notna().sum():,} of {len(picks):,} picks\")\n",
+    "picks[[\"conf\", \"amp\", \"amp_raw\"]].describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Reading without a single LIST\n",
+    "\n",
+    "§4 and §5 let the engine prune partitions, but pruning still **lists** the\n",
+    "prefixes it keeps. For a service, or any tight loop where request latency\n",
+    "matters, the manifests are an index: they record the exact object keys each job\n",
+    "wrote, which a reader cannot reconstruct from the file name because it carries\n",
+    "a content hash and a flush sequence number.\n",
+    "\n",
+    "`shards.jsonl` -> `manifests/<shard_id>.json` -> object. GETs only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyarrow.parquet as pq\n",
+    "\n",
+    "WANT, DAY = \"CI.CLC.\", \"2019.187\"\n",
+    "\n",
+    "# 1 GET: the queue says which shard covers this station and day.\n",
+    "shards = [json.loads(l) for l in\n",
+    "          fs.cat(f\"{root}/shards.jsonl\").decode().splitlines() if l.strip()]\n",
+    "hits = [s for s in shards if WANT in s[\"stations\"] and s[\"start\"] <= DAY < s[\"end\"]]\n",
+    "print(f\"{len(hits)} shard(s) cover {WANT} on {DAY}\")\n",
+    "\n",
+    "for s in hits:\n",
+    "    # 1 GET: the manifest names the objects that shard produced.\n",
+    "    key = f\"{root}/manifests/{s['shard_id']}.json\"\n",
+    "    if not fs.exists(key):\n",
+    "        print(f\"  {s['shard_id']}: not finished yet\")\n",
+    "        continue\n",
+    "    manifest = json.loads(fs.cat(key))\n",
+    "    for f in manifest[\"files\"]:\n",
+    "        if f[\"kind\"] != \"picks\":\n",
+    "            continue\n",
+    "        # 1 GET: straight to the object. No LIST anywhere in this path.\n",
+    "        t = pq.read_table(f[\"path\"], filesystem=fs,\n",
+    "                          columns=[\"tid\", \"pha\", \"peak\", \"conf\", \"amp\"])\n",
+    "        print(f\"  {f['path'].split('/')[-1]}: {t.num_rows:,} rows\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Provenance\n",
+    "\n",
+    "Every pick carries `rid`, which resolves to the model, weight and thresholds\n",
+    "that produced it — what `sb_runs` did. This is how picks from different weights\n",
+    "stay separable inside one campaign."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for r in fs.glob(f\"{root}/runs/*.json\")[:5]:\n",
+    "    print(json.loads(fs.cat(r)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Re-running part of a campaign\n",
+    "\n",
+    "There is no DANGER ZONE here, and that is the point. Parquet objects are\n",
+    "immutable and named after the shard that wrote them, so a re-run **overwrites\n",
+    "itself byte for byte** rather than duplicating rows — no `delete_many` before\n",
+    "re-picking, and no unique index to maintain.\n",
+    "\n",
+    "To redo a shard, delete its completion marker and let a worker claim it again:\n",
+    "\n",
+    "```python\n",
+    "fs.rm(f\"{root}/complete/{shard_id}.json\")\n",
+    "fs.rm(f\"{root}/progress/{shard_id}.json\")   # also discard partial progress\n",
+    "```\n",
+    "\n",
+    "To discard a campaign entirely, delete the prefix. Nothing is running, so there\n",
+    "is nothing to stop first — unlike a DocumentDB cluster, which had to be deleted\n",
+    "or it kept billing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # Redo one shard:\n",
+    "# shard_id = \"2019001-2019021-abc123def456\"\n",
+    "# for k in (f\"{root}/complete/{shard_id}.json\", f\"{root}/progress/{shard_id}.json\"):\n",
+    "#     if fs.exists(k):\n",
+    "#         fs.rm(k)\n",
+    "#         print(\"removed\", k)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.10"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pixi.lock
+++ b/pixi.lock
@@ -2699,6 +2699,1524 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/0e/ea0f4a563253b6363195a4f704123c6bfbf156641bd3be5a75de81c5e917/orjson-3.12.0-cp310-cp310-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
+  deploy:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/pytorch/
+    - url: https://conda.anaconda.org/nvidia/
+    indexes:
+    - https://pypi.org/simple
+    options:
+      channel-priority: disabled
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.14.3-py310h31b6992_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py310h7c4b9e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.4-hb7a77c6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.14-h2aa3ae6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.14.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h720e601_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.1-h6ffeea8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.11.0-h38ae05a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.27.3-h6f4d18d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.16.0-h21f4ec5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.8-h46fcd08_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h720e601_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h720e601_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.40.1-h102d43b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.833-hc7390e0_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.14.0-hf596fc9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.16.0-h1f05bef_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.7.0-py310hff74037_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-h505cf86_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-h9908984_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py310h25d4438_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.25.0-np2py310h3d4ba91_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.1-py310hd4ea0ea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.2-py310h3788b33_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py310h25320af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py310h3406613_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py310h9548a50_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.3.1-h54a6638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hb7133d2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.5-py310h25320af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py310haaf941d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-25.0.0-hcc2f0d9_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-25.0.0-h635bf11_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-25.0.0-h53684a4_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-25.0.0-h635bf11_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-25.0.0-h66fbfdd_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_hd70ba2e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.8.0-hbc29df5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.8.0-hdbdcf42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.82.1-h792040b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.3.1-h23af247_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.8-hf7376ad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h3133023_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-25.0.0-h7376487_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-7.35.1-h2840a7c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h60473fc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-hebe6cf0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h5279c79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-h51789e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.1.2-py310h04e47aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-hee9eb32_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py310h3406613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.9-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py310hfde16b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py310h3406613_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py310hefbff90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/obspy-1.5.0-py310hf779ad0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.1-h443056b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.3-py310h0158d43_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py310h5a73078_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.6.2-h18fbb6c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.5.2-py310h3406613_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py310h139afa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-25.0.0-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-25.0.0-py310h382fff3_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.2-py310ha8dd31c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py310ha71cbf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py310hd8f68c5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py310h1d65ade_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.2-py310hc8bbb35_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.52-py310h139afa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.4-h9ffa6c4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py310h7c4b9e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py310h7c4b9e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.3.0-py310h7c4b9e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-hebe6cf0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.24.5-py310h3406613_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.9.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.56-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.56-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.3.0-pyha191276_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.37.0-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.1.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.2.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.17-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.26.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.53-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.53-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.1.6-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.22.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.3.post1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.16-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/c8/79eee650c62d2c186598489814468e389b5def0ebe755399ff645b35b1b2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/08/07/facef6abd81378e6153b757dc1848621675d971fbc88ebb5d182ebc1c37f/casbin-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0d/e3/dbbf4b102f4e6aaf49ad3749a6d778f309473a2950c5ce3bb20b94f2ba84/bottleneck-1.6.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/f8/17bda581c517678260e6541b600eeb67745f53596dc077174141ba2f6702/setproctitle-1.3.7-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/15/76/c79c34311625227a288df3e483fc5cdf3d596624cbd4b4758c4cbdc14af3/triton-3.7.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/f0/1ff90a1d1dd02de23feafdf9dffaecef3958348be5c192df56670ccb4f86/stamina-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/23/49/0c823a7627ff2e69a61e4a53c4edf215272892fc2c47c6431f033d46f4cc/grpcio-1.83.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/4c/16/fca52784f979821e2205ff514322d0e83452536acc4807a79ddb2085bbb2/types_paramiko-5.0.0.20260724-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4f/c9/7352e0c20fe772541556e4d283c05e07ec48f8b0d2737ad930ac4a1b6655/pymongo-4.17.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/50/c0/68a84105e1fcb8970144b388ff3d3e5dc15a3be28c1e247841f7d7247e41/torch-2.13.0-cp310-cp310-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/02/d2b8ec2172577329daec50b0e547ac68955e04983ae42367fe3ae8388229/aioboto3-7.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/64/fe/da28a5916128d541da0993328dc5cf4b43dfbf6655f2c7a2abe26ca2dc88/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/65/9b/4df366d89f28c527dc39d0b6c98a5ca74e30d37ac097b73f3352147568ae/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/5c/3102e8c039e70f7e8cf579dbcdfbf5244860565c10d5e74a7cd608ccc960/earthscope_sdk-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/75/20/930824c07685c22af23f26818ed3853b0270488a412b6ab757904b7f787b/orjson-3.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/85/bfd277c82b52318725499855e7ea42368d49df3327dbc63ea16ba9973fc0/sqlalchemy_adapter-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/ea/e4d3f64822fb29d54970909e1e2784daa17f75fe3c6c27544fe92e247aad/ijson-3.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/1f/5ef51f5fbaa5d4d3201bb3d7555af028ec1aa4416275ccbf73c9e34e3d2d/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ae/72/cecb1710c36c6fe61e545050607c2050a2af0b991cf1a3d83981dfd895e8/pendulum-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/f6/21657bb3beb5f8c57ce8be3b83f653dd7933c2fd00545ed1b092d464799a/uvloop-0.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bb/c6/0cd524132e0a558ce8ee0a32bd2308c18abd84a2c9374dc909146244534c/pyocto-0.1.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/92/a8851d936547efe30cc0ce5245feac01f3ec6171f7899bc3f775c72030b3/h5py-3.16.0-cp310-cp310-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/d9/a503213b79d362e7a5da595dd7fa38186a6d1adb3642466f1399045bafe2/skypilot-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/98/1a853f6870ac7ad48383a948c8ff3c85dc278066a4d69fc9af7d3d4b1106/asyncpg-0.31.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/6e/d674f1dde91c71e2ac19e5e5cf1ee6d5845e3aefecd9c39ed9c4b0c9a696/pulp-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/13/775b5b79cb686dc9f9133f1f73079102e312866500556c1b604f72e7b68b/awscli-1.46.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/e3/0f15da0fb5864a37637820e4bde463a52ba0c052a8edab06aad46b9e578b/pycasbin-2.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/1e/2942a0d6d52240d439f44384a40c65d359d9ca70325b65b265c020113121/cuda_pathfinder-1.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e6/e4/77487e14fc7be47180fd0eb4267c7486d0cc59b74031839a3daf8650136b/httptools-0.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/93/0c0f002031f18b53af7a6166103c02b9c0667be528944137cc954ec921b3/rsa-4.7.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/f9/44c8108722acb8613752107131146c75a27b1be554c0a1bb0868a5700fb2/pymseed-0.9.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/18/a17e2f0cde02dc10154c808deed7e1d8528afff93612f70d3f0a5b19b011/websockets-16.1.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/a2/c8bf64a5d8d2e8506ccd09addb76b7a240cb8b1a5b67e9b814dc5c17eec7/seisbench-0.12.5-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.9.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.56-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.56-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.3.0-pyh01cf8df_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.37.0-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.1.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.2.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.17-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.26.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.53-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.53-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.1.6-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.22.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.3.post1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyh5552912_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.16-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.14.3-py310h106fdd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-25.1.0-py310hd2d5e8d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.10.4-h74cc20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.9.14-h1727fe8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.14.2-ha1e9b39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.3.2-h83f6fd2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.7.1-h8a1f669_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.11.0-h6a26125_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.27.3-h1fab602_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.16.0-h3619873_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.12.8-h4da758a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.2.7-h83f6fd2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.10-h83f6fd2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.40.1-hfc09f7c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.833-hcd60bbe_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.16.3-hce1ca1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.13.3-hfaa3f56_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.18.0-h5a4125c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.14.0-hdf1104b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.16.0-hf005220_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.7.0-py310h80e3c0f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.2.0-ha9642f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.2.0-h086410e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.2.0-py310h6006261_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.25.0-np2py310hf83fa34_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.1.1-py310h489c87a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.3.2-py310hf166250_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.21-py310h3f55cb5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.63.0-py310h399bfa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.3-h694c41f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.8.0-py310hef20fdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.3.1-h2fb4741_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h90d9b41_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/greenlet-3.5.5-py310h3f55cb5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.5.0-py310h323244c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h69064fd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.19.1-h5ea7634_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.2.0-h35c7297_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20260526.0-cxx17_h6e8c311_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-25.0.0-he333e4a_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-25.0.0-h620650e_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-compute-25.0.0-h03721a0_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-25.0.0-h620650e_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-25.0.0-h0ec1645_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-9_he492b99_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-9_h9b27e0a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.21.0-h8f0b9e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.25-h7ad9622_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321hba2e2ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.3-h694c41f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.3-h8afe040_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.1.0-h13771c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.1.0-h7e5c614_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.1.0-h70d9f54_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.8.0-he806f76_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-3.8.0-h1159701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.82.1-h00dac5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.2.0-ha1e9b39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-9_h859234e_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.34-openmp_h9e49c7b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-1.27.0-h3bf6f87_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.27.0-h694c41f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-25.0.0-hd9337e7_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.58-h4382c61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-7.35.1-h087ac9f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2025.11.05-h962f25e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.22-had63097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hd53bb72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.22.0-hebea4ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.2-h95d6d7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.11.3-hc282952_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.6.0-hb276fe9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-h2478c6c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h0d7f165_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h0712280_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxslt-1.1.43-h486b42e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lxml-6.1.2-py310hc6132bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-hc569e58_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py310h399bfa0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.10.9-py310h2ec42d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.9-py310hcb54904_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.7.1-py310hf174c55_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nlohmann_json-3.12.0-h2fb4741_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.2.6-py310h07c5b4d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/obspy-1.5.0-py310h0592eca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h52bb76a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.3-hc881268_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.3.1-h982cfee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.3.3-py310h39ce848_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-12.3.0-py310h0c0a54c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.6.2-h8462e38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.5.2-py310h399bfa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py310h8bcfd8d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-ha1e9b39_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-25.0.0-py310h2ec42d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-25.0.0-py310h16e9edb_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.2.2-py310h34f91f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.2.2-py310h489c87a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.1-py310h805e0b6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.20-hea035f4_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.3-py310hec06124_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-27.1.0-py310h30bd05a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2025.11.05-hcc9a9c6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.30.0-py310h64024f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/s2n-1.7.5-he8c8f02_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.15.2-py310hef62574_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.1.2-py310hd250500_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.2-h01f5ddf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlalchemy-2.0.52-py310h5afac17_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.53.4-hdea7a7b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hb794df6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.5.8-py310h5cd8a12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-17.0.1-py310hf70ac88_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-2.3.0-py310h5cd8a12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.12-ha1e9b39_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-ha1e9b39_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-had63097_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.24.5-py310h399bfa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h84953be_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.3-h646e873_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+      - pypi: https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/08/07/facef6abd81378e6153b757dc1848621675d971fbc88ebb5d182ebc1c37f/casbin-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0d/5a/2bf22ecb24916983bf1cc0095e7dea2741d14d6553b0d6a2ac8bc96eca93/watchfiles-1.2.0-cp310-cp310-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/74/c6f769aad8af584096d7e7d7d56ff081a2c9ee7a8a93d6ddea92ad26808a/seisbench-0.12.5.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/14/d8/6d641573e210768816023a64966d66463f2ce9fc9945fa03290c8a18f87c/bottleneck-1.6.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/1d/f0/1ff90a1d1dd02de23feafdf9dffaecef3958348be5c192df56670ccb4f86/stamina-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/6b/231413e58a787a89b316bb0d1777da3c62257e4797e09afd8d17ad3549dc/h5py-3.16.0-cp310-cp310-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/55/7192974ab13e5e5577f45d14ce70d42f5a9a686b4f57bbe8c9ab45c4a61a/torch-2.2.2-cp310-none-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/40/b9/be66eb0decd730d89b9c94f930e4b8d87787b05724bb84af98bfd825f72c/httptools-0.8.0-cp310-cp310-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4c/16/fca52784f979821e2205ff514322d0e83452536acc4807a79ddb2085bbb2/types_paramiko-5.0.0.20260724-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/02/d2b8ec2172577329daec50b0e547ac68955e04983ae42367fe3ae8388229/aioboto3-7.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/5c/3102e8c039e70f7e8cf579dbcdfbf5244860565c10d5e74a7cd608ccc960/earthscope_sdk-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/80/49bacf9e51617d8309f6f0123e29edc793f6f5f6700c7d1f1b20782fbb37/psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/f5/70df723bf571f5e0b1b845e0a4ff1c966eeb84f667599fc251caa37d15a3/websockets-16.1.1-cp310-cp310-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/85/bfd277c82b52318725499855e7ea42368d49df3327dbc63ea16ba9973fc0/sqlalchemy_adapter-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/ad/8d9e1f076560efcc6727b06f3276f30bb811961332d83567de70c179e0e8/ijson-3.5.1-cp310-cp310-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/ae/6f6f9af7f590b319c94532b9567409ba11f4fa71af1148cab1bf48a07048/uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/d9/507c80bdac2e95e5a525644af94b03fa7f9a44596a84bd48a6e80f854f92/asyncpg-0.31.0-cp310-cp310-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/77/28ebbf69772a4341d530831c7a006cdb06877ac23075cb53b0a227df4fe1/pymongo-4.17.0-cp310-cp310-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/a4/934d8c97851bda5a034b0fd0512689173c8ca8cb3b87ebf8e5c1364d57f3/pendulum-3.2.0-cp310-cp310-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/d9/a503213b79d362e7a5da595dd7fa38186a6d1adb3642466f1399045bafe2/skypilot-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cf/35/819eeb4fa8ee676d38fdbb8213a76fd496f7dbbfdfafa89d34e02b22dfac/orjson-3.12.0-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/9a/1ce5760d35a04a992006dd2f79afff2db548f93ee7426fa95c9f1fc90c61/grpcio-1.83.0-cp310-cp310-macosx_11_0_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/fa/f9e8b816e7d55b98777126cc38ad986a314bd86d258b6af01c09512a2ff1/pymseed-0.9.5-cp310-cp310-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/6e/d674f1dde91c71e2ac19e5e5cf1ee6d5845e3aefecd9c39ed9c4b0c9a696/pulp-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/13/775b5b79cb686dc9f9133f1f73079102e312866500556c1b604f72e7b68b/awscli-1.46.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/e3/0f15da0fb5864a37637820e4bde463a52ba0c052a8edab06aad46b9e578b/pycasbin-2.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/b9/d3d7708a5d7641e2a1fa703c69c5ad10334a6ced4c0bd46486c1f69871f1/pyocto-0.1.4-cp310-cp310-macosx_10_9_universal2.macosx_10_9_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/93/0c0f002031f18b53af7a6166103c02b9c0667be528944137cc954ec921b3/rsa-4.7.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f2/48/fb401ec8c4953d519d05c87feca816ad668b8258448ff60579ac7a1c1386/setproctitle-1.3.7-cp310-cp310-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.9.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.56-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.56-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.3.0-pyh01cf8df_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.37.0-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.1.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.2.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.17-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.26.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.53-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.53-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.1.6-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.22.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.3.post1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyh5552912_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.16-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.14.3-py310hd5e7861_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-25.1.0-py310hfe3a0ae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.10.4-h0f08c97_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.14-hb9ed60c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.14.2-h84a0fba_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.3.2-hf0b4b85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-ha581b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.11.0-h27f0cb5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.27.3-ha24efe8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-hf1a914d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.12.8-hdc61527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.2.7-hf0b4b85_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-hf0b4b85_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-h5b5d287_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.833-haa98fb3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.14.0-h7cba3ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.16.0-h16bb3af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.7.0-py310h94e62c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.2.0-hf00d406_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.2.0-he4a93e4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py310h4d9ebb8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.25.0-np2py310hd9bf50c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.1-py310hacfb2a5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.2-py310h7f4e7e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.21-py310h19b6747_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.63.0-py310hb46c203_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.8.0-py310hb0559e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.3.1-h784d473_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-h6f9ecc1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.5.5-py310h19b6747_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.5.0-py310h34990b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h34f8a20_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.19.1-hdfa7624_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.2.0-h1eee2c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260526.0-cxx17_h4c27e2a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-25.0.0-haaed7fe_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-25.0.0-heaff1e6_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-compute-25.0.0-h93a2d87_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-25.0.0-heaff1e6_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-25.0.0-h2208e57_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-9_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-9_hb0561ab_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-h6651222_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-he7e0567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321h26f1114_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-h2ed5691_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.1.0-h3cf6597_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.1.0-h07b0088_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.1.0-h32cdfcc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.8.0-ha595bda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.8.0-hc8aed40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-9_hd9741b5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.34-openmp_he657e61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h46c1d2a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_4_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-hf5e6511_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.1-hdb0c161_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h5d15848_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h74c22ad_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-hbf2880b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.22.0-h1fb9c8a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.2-h282da08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.11.3-h2431656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h202fb40_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hbffa61f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxslt-1.1.43-hb2570ba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.1.2-py310h164b0d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-hdca3b7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py310hb46c203_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.10.9-py310hb6292c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.9-py310h610ac43_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py310h53a546b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.2.6-py310h4d83441_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/obspy-1.5.0-py310h1d5274f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.3-py310h25f4b65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.3.0-py310hc037f36_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.6.2-hdbeaa80_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.5.2-py310hb46c203_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py310haea493c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h84a0fba_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-25.0.0-py310hb6292c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-25.0.0-py310h92a7759_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.2.2-py310h33d7b5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.2.2-py310h52cee4a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.1-py310h5b9b180_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-hac0b6dc_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py310hb46c203_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py310hf396ece_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-h5d60da5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py310hf3301a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/s2n-1.7.5-h1b28cb6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.15.2-py310h32ab4ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.1.2-py310h9f28be2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.52-py310hccdf4e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.4-ha9f7ffe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.8-py310h72544b6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py310h72544b6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.3.0-py310h72544b6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h84a0fba_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-h84a0fba_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h74c22ad_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.24.5-py310hb46c203_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-h31dac16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+      - pypi: https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/08/07/facef6abd81378e6153b757dc1848621675d971fbc88ebb5d182ebc1c37f/casbin-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/f0/1ff90a1d1dd02de23feafdf9dffaecef3958348be5c192df56670ccb4f86/stamina-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/f6/6329a1303afb6120cabf8e47ae1bbd9349f9f3794144c02fa4430a363b02/pymseed-0.9.5-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/47/92/2091275a9025f9b9ef9bf72ae386786a9b03af9515f5e2f5befb012ec91f/pendulum-3.2.0-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/4c/16/fca52784f979821e2205ff514322d0e83452536acc4807a79ddb2085bbb2/types_paramiko-5.0.0.20260724-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/55/70/dea1f6a0e76607841a60fb51af150e70124864673f61704abb62b90cdcc7/watchfiles-1.2.0-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/02/d2b8ec2172577329daec50b0e547ac68955e04983ae42367fe3ae8388229/aioboto3-7.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/5c/3102e8c039e70f7e8cf579dbcdfbf5244860565c10d5e74a7cd608ccc960/earthscope_sdk-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/74/f9/557ce3aad0fe8471fb5279bab0fc56ea473858a022c4ce8a0b8f303d64e9/h5py-3.16.0-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/cf/5a70cee503ff9a2fea20607607f14d189f4d975960ac0945ec306ee7b695/pymongo-4.17.0-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/90/72/2f14b2e167170b8bf1c8bb7f9b0d78000f470d41a2085a91f33e3917b6c9/websockets-16.1.1-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/85/bfd277c82b52318725499855e7ea42368d49df3327dbc63ea16ba9973fc0/sqlalchemy_adapter-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/38/144fb32c9efb196f651ddb30e7c48f6047a86972e5b350f3f10c9a5f6a16/bottleneck-1.6.0-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/f7/b4d41eaae2869d31356bc4bbf546f44fae83ff298af0a043ca0625b06773/httptools-0.8.0-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ab/e7/8f001e823846c270e0e9c3526ea99dc3b1ba51b9501e060d8337830d6c76/ijson-3.5.1-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/d9/a503213b79d362e7a5da595dd7fa38186a6d1adb3642466f1399045bafe2/skypilot-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/a3/c2b0333c2716fb3b4c9a973dd113366ac51b4f8d56b500f4f8f704b4817a/setproctitle-1.3.7-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cf/35/819eeb4fa8ee676d38fdbb8213a76fd496f7dbbfdfafa89d34e02b22dfac/orjson-3.12.0-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d3/5e/3a662f35ab7a9aa44a7c943335dabfbcc9ea6fa4921909aec4c6996dea4c/seisbench-0.12.5-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/d3/f2/98eeac7d60c43df9338287834edf9b3e69be68a2db78a57b1b81d705e735/psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/9a/1ce5760d35a04a992006dd2f79afff2db548f93ee7426fa95c9f1fc90c61/grpcio-1.83.0-cp310-cp310-macosx_11_0_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/6e/d674f1dde91c71e2ac19e5e5cf1ee6d5845e3aefecd9c39ed9c4b0c9a696/pulp-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/13/775b5b79cb686dc9f9133f1f73079102e312866500556c1b604f72e7b68b/awscli-1.46.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/e3/0f15da0fb5864a37637820e4bde463a52ba0c052a8edab06aad46b9e578b/pycasbin-2.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/b9/d3d7708a5d7641e2a1fa703c69c5ad10334a6ced4c0bd46486c1f69871f1/pyocto-0.1.4-cp310-cp310-macosx_10_9_universal2.macosx_10_9_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/93/0c0f002031f18b53af7a6166103c02b9c0667be528944137cc954ec921b3/rsa-4.7.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ea/03/f93b5e543f65c5f504e91405e8d21bb9e600548be95032951a754781a41d/asyncpg-0.31.0-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.9.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.56-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.56-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.3.0-pyh6dadd2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.37.0-pyha7b4d00_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.1.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.2.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyh6dadd2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.17-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.26.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.53-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.53-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.1.6-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.22.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.3.post1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyh6dadd2b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh6dadd2b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyha7b4d00_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.16-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.14.3-py310h3602819_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-25.1.0-py310h29418f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.10.4-hc6e9107_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.9.14-h032d170_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.14.2-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.2-h1da161f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.7.1-h88938e3_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.11.0-h667fc28_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.27.3-hbdc738f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.16.0-hd7b40c3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.12.8-hd7ee1a1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.7-h1da161f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.10-h1da161f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.40.1-he7c1723_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.833-hdf1b151_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.16.3-h49e36cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.13.3-hf9fdf8e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.18.0-h4fb3251_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.14.0-hf9fdf8e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-files-datalake-cpp-12.16.0-heb2e695_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.7.0-py310h458dff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.2.0-hc8c2fe1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.2.0-hd477307_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.2.0-py310h967a849_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.8-h6a83c73_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.4-h477c42c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cartopy-0.25.0-np2py310h7578f05_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.1.1-py310h29418f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.2-py310hc19bc0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.21-py310h699e580_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.4.0-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.18.3-hd47e2ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.63.0-py310hdb0e946_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.3-h57928b3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.8.0-py310had1666a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.15-h5112557_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/greenlet-3.5.5-py310h699e580_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h5112557_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.5.0-py310h1e1005b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h719d79b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.19.1-hf2c6c5f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.2.0-hd936e49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20260526.0-cxx17_h04e5de1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-25.0.0-h20c36f3_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-25.0.0-h7d8d6a5_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-compute-25.0.0-h081cd8e_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-25.0.0-h7d8d6a5_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-25.0.0-hffb5221_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-9_h8455456_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.2.0-hf02afa3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.2.0-h84f9c24_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.2.0-he2a975b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-9_h2a3cdd5_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-22.1.8-default_h2778606_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.21.0-hdb0ef4a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h1a1d4e4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.14.3-h57928b3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.14.3-hdbac1cb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-16.1.0-h110b43a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.88.3-he810d59_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-16.1.0-h8ee18e1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.7.0-hfe3f7e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-3.7.0-he04ea4c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.82.1-he6cc664_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libharfbuzz-14.3.1-h03b5201_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.2.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-9_hf9ab0e9_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopentelemetry-cpp-1.27.0-h4cd8edf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopentelemetry-cpp-headers-1.27.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-25.0.0-h7051d1f_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.58-hdc8cecf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-7.35.1-h1a71995_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpsl-0.23.1-h9b16d47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.11.05-h45f70d9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.22-h6a83c73_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h734d217_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.22.0-h2e43b2f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.2-h8f73337_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.11.3-hb980946_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libvulkan-loader-1.4.357.0-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h874e120_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.3-h3cfd58e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.3-h8ef44ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxslt-1.1.43-h0fbe4c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-22.1.8-h4fa8253_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lxml-6.1.2-py310h095aac5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.10.0-h6a83c73_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.3-py310hdb0e946_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.10.9-py310h5588dad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.10.9-py310h0bdd906_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2026.1.0-hac47afa_234.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.7.1-py310hdb0e946_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/nlohmann_json-3.12.0-h5112557_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.2.6-py310h4987827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/obspy-1.5.0-py310h8f3aa81_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.4-h0e57b4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.3-hf411b9b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.3.1-hf7eca67_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.3-py310hed136d8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-12.3.0-py310h712baa7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.4-h5112557_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.6.2-h7990399_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/prometheus-cpp-1.3.0-hcea2f5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.5.2-py310hdb0e946_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py310h1637853_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hba3369d_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-25.0.0-py310h5588dad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-25.0.0-py310hc34f82c_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.1-py310h61ea1ad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.2-py310h059d4f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.20-hc20f281_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-312-py310h282bd7d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-3.0.5-py310h9e98ed7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py310hdb0e946_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.1.0-py310h824d4bc_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.11.2-pl5321hfcac499_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2025.11.05-haef9524_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py310h034784e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.15.2-py310h15c175c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.1.2-py310h62de375_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlalchemy-2.0.52-py310h1637853_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.53.4-hdb435a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.8-py310h29418f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-17.0.1-py310h29418f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-ha367084_41.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36247-habf1de7_41.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36247-habf1de7_41.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36247-h633cb9f_41.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-2.3.0-py310h29418f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-hba3369d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.5-hba3369d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yarl-1.24.5-py310hdb0e946_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h3a581c9_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_7.conda
+      - pypi: https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/08/07/facef6abd81378e6153b757dc1848621675d971fbc88ebb5d182ebc1c37f/casbin-1.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/f0/1ff90a1d1dd02de23feafdf9dffaecef3958348be5c192df56670ccb4f86/stamina-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b4/9fbb4b0af4e36d96a61d026dd37acab3cf521a70290a09640b215da5ab7c/asyncpg-0.31.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/22/fa/b4e71bb8cb82ad7d21bb4e8c476f2d573ba68b20368aac36ef06e4a196b4/pymongo-4.17.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/28/d5/0a944773749b8659556a957f027332f939cb6913fb88267d8a5fbd026180/pyocto-0.1.4-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/c9/0bb9d097b03cbaf96bb75b15e867347b8e41bfcdfe0539452d17d9e63993/torch-2.13.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/2f/75/8f0e8e266ea99ffbc69500a927f0c114a07fe465bfbc59871d6fe22d9ee0/bottleneck-1.6.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/46/81/d8c22cd7e5e1c6a7d48e41a1d1d46c92f17dae70a54d9814f746e6027dec/bcrypt-4.0.1-cp36-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/4c/16/fca52784f979821e2205ff514322d0e83452536acc4807a79ddb2085bbb2/types_paramiko-5.0.0.20260724-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/82/1013a5fe7ddae8e102bc3b4b39db81d8d28fd02100a324ce6ede8cd832b1/websockets-16.1.1-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/57/dd/babfb85ad163c1eadb06bd813571532cdee4b4a356817cb481da8165136c/seisbench-0.12.5-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/02/d2b8ec2172577329daec50b0e547ac68955e04983ae42367fe3ae8388229/aioboto3-7.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/35/d88fd6718832133c885004c61ceeeb24dbd6397ef877dbed6b3a64d6a286/h5py-3.16.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/5c/3102e8c039e70f7e8cf579dbcdfbf5244860565c10d5e74a7cd608ccc960/earthscope_sdk-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/68/a5e67b6b68e94f4c1511d61c46c55eba0737583620b6febf194c7b9cc23f/watchfiles-1.2.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/73/99/21af7a5498637ea4dc91a17c281a53bc1d632fbafe00f6689fbfb32a9fed/psycopg2_binary-2.9.12-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/85/bfd277c82b52318725499855e7ea42368d49df3327dbc63ea16ba9973fc0/sqlalchemy_adapter-1.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/2f/f1bcdc92c381855f95ecb7a4714a31886a7bb2b704d467455c422e7bf4cb/pymseed-0.9.5-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bb/e8/86b85bbc0ac7892232f1a99ab96a9aa71936984fa06adfc0afc83ca7789e/httptools-0.8.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/d9/a503213b79d362e7a5da595dd7fa38186a6d1adb3642466f1399045bafe2/skypilot-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/0e/ea0f4a563253b6363195a4f704123c6bfbf156641bd3be5a75de81c5e917/orjson-3.12.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cf/c1/165f10f2e37978caf92a1dca71726e7cd5d8de4039f9f4a6d1994a9b8d7f/pendulum-3.2.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/fe/dd206cc19a25561921456f6cb12b405635319299b6f366e0bebe872abc18/setproctitle-1.3.7-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/6e/d674f1dde91c71e2ac19e5e5cf1ee6d5845e3aefecd9c39ed9c4b0c9a696/pulp-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/13/775b5b79cb686dc9f9133f1f73079102e312866500556c1b604f72e7b68b/awscli-1.46.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/e3/0f15da0fb5864a37637820e4bde463a52ba0c052a8edab06aad46b9e578b/pycasbin-2.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/93/0c0f002031f18b53af7a6166103c02b9c0667be528944137cc954ec921b3/rsa-4.7.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/ef/a707b5830722e9f7af347945f9ee0f360d38922366bc1400c6177154eb9c/ijson-3.5.1-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/8e/ce9a23590cac33a6c24e6386cc0ffc55821cc13212acc822e98f00a67161/grpcio-1.83.0-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -6648,6 +8166,21 @@ packages:
   run_exports: {}
   size: 192901
   timestamp: 1781450813638
+- conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.7.0-py310hff74037_0.conda
+  sha256: f86c944b95c943f6c7b797e389a9210fb9dc7ea838d1d0815a240cfaa3188893
+  md5: 3a5e1bf41b700d667440ae26654dd70a
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - zstd >=1.5.7,<1.6.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  purls:
+  - pkg:pypi/backports-zstd?source=hash-mapping
+  run_exports: {}
+  size: 193635
+  timestamp: 1786861406844
 - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-h505cf86_3.conda
   sha256: 1f2ccfebe6e0113bfc473b21906372c1ee4eb69bf6faef0ad7f3d4d79af63a98
   md5: 6ff307b78fbfb7dcafb7e25ff8bc9c10
@@ -6729,6 +8262,20 @@ packages:
     - c-ares >=1.34.8,<2.0a0
   size: 226755
   timestamp: 1786116641939
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+  sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+  md5: 3ad2b403be8fc5612b9159e2ce621f69
+  depends:
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.8,<2.0a0
+  size: 228700
+  timestamp: 1787169971173
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
   sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
   md5: bb6c4808bfa69d6f7f6b07e5846ced37
@@ -7191,6 +8738,25 @@ packages:
     - lerc >=4.2.0,<5.0a0
   size: 271158
   timestamp: 1785036167977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
+  sha256: 7bb3d495411b7059e85225aae500d84e7846a4bb02ebd77e4450200b20c180f0
+  md5: 6983bfe8e09992014b9cf393769c7a84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - abseil-cpp =20260526.0
+  - libabseil-static =20260526.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - libabseil >=20260526.0,<20260527.0a0
+    - libabseil =*=cxx17*
+  size: 1436888
+  timestamp: 1787217011773
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
   sha256: 32933de2d4fa6e6ffd949052815b49cb65a0649ad70007155c533ab97ea8cefd
   md5: c4393db381bffa0a83a8d9e47b238106
@@ -7569,6 +9135,27 @@ packages:
   run_exports: {}
   size: 43805393
   timestamp: 1779897559895
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
+  sha256: 0b6cc13e36cf19ae9b764740112fc591682e189c99353be9f72f3d96ccf29d79
+  md5: 0ed167049513943d078a6c997df2b4e0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=15
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libpsl >=0.23.1,<0.24.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 484517
+  timestamp: 1787183722915
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
   sha256: aff8ef75636d0825ce34911e0bef2f26816e7afd090a9dcb4b9bacab75cbf584
   md5: 3f2fd5617cfacac49c85f6dc63842ea1
@@ -7757,6 +9344,21 @@ packages:
   run_exports: {}
   size: 1057877
   timestamp: 1785375436766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_2.conda
+  sha256: 4b733b68027a638fd24a38aaed1ebb05e055bef694970fab745b1c7678ca16f1
+  md5: b230041fd4acdd1127ef5870174310ef
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==16.1.0=*_2
+  - libgomp 16.1.0 he0feb66_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 1056637
+  timestamp: 1787165351282
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
   sha256: 225275c562337a1cd61705da0ee4235dde7bba7504de1c34b74c894adb2b0eee
   md5: 7ed870c014a6f23c7dfafda53d2763a9
@@ -7770,6 +9372,19 @@ packages:
     - libgcc
   size: 28210
   timestamp: 1785375440733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_2.conda
+  sha256: 23bfa3ade2de6e0b9af4a04cacd0d4d526c80a16686f264498475339f01d17d3
+  md5: be5ca38a4a2ddfda85ad7aae7d67238a
+  depends:
+  - libgcc 16.1.0 ha9f2e26_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - libgcc
+  size: 28293
+  timestamp: 1787165356218
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
   sha256: 9e82d410a50bd4e5e47cbbb026454c3eb543954baca4db23929575b571bf56a3
   md5: 2fbed65cc90cf0724e1ec4de13696737
@@ -7783,6 +9398,19 @@ packages:
   run_exports: {}
   size: 28134
   timestamp: 1785375470055
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_2.conda
+  sha256: f608de89b2579d0e3ffa748476ad50e26ef3f9adf9ebbb619db679663cbf88ac
+  md5: 85c8f13b26afe335c9df928995f56683
+  depends:
+  - libgfortran5 16.1.0 h79bb938_2
+  constrains:
+  - libgfortran-ng ==16.1.0=*_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 28257
+  timestamp: 1787165383846
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
   sha256: 05078ab464d506dff971860cb1a553b35bc27c0b5ce8ec29b8bfaca5f2359652
   md5: dd51ed33e8c70995f8e33cc9dc537297
@@ -7797,6 +9425,20 @@ packages:
   run_exports: {}
   size: 2538696
   timestamp: 1785375448623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_2.conda
+  sha256: 627b865f5ba4da4d5508e90453d9419f28ed8a72f8577086681b589cf9579fab
+  md5: 60fe1556f159aad832acef6bf8a5102d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=16.1.0
+  constrains:
+  - libgfortran 16.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 2538899
+  timestamp: 1787165364214
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
   sha256: ec353b3076ed8e357ed961d0e9ff6997491cade0e603de5bd18a2e301ac78ebd
   md5: f25206d7322c0e9648e8b83694d143ab
@@ -7892,6 +9534,19 @@ packages:
     - _openmp_mutex >=4.5
   size: 640415
   timestamp: 1785375373755
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_2.conda
+  sha256: 7d4d1891d5fe5d75a73dd7268e8f2d7c11b7b637dea901a429f8056511960267
+  md5: 583bc8fce86ce542fa9a25c5b4d71e80
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 640468
+  timestamp: 1787165281830
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.8.0-hbc29df5_0.conda
   sha256: 46126b858d173d6808262e39e3a8aa39946d39aebb5ffb720984dc44f74feafe
   md5: 60ff8935e16bf2fd302289ec4f129df8
@@ -7983,6 +9638,27 @@ packages:
   run_exports: {}
   size: 1333436
   timestamp: 1785770053613
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.3.1-h23af247_0.conda
+  sha256: a4eac5a21b84e0fc753b72de01781f634fc9ab70fd32a28d6a40a19700c9188a
+  md5: 29709e61096dd490fff9e833e4c869f6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.15,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=15
+  - libglib >=2.88.3,<3.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 1353639
+  timestamp: 1786970872936
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.3.0-h17a8019_0.conda
   sha256: 7ce9326c2520ae758f523ae2d72a0762f7494d77fe8cc9a96065df541e1db8e2
   md5: 15634b3c7e5a68ca7c6e0bbf84cb2383
@@ -8025,6 +9701,19 @@ packages:
     - libhwloc >=2.13.0,<2.13.1.0a0
   size: 2436378
   timestamp: 1770953868164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+  md5: f92233bf33e24a25668bb2119e2c51f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: LGPL-2.1-only
+  purls: []
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
+  size: 789471
+  timestamp: 1787033836207
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
   sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
   md5: 915f5995e94f60e9a4826e0b0920ee88
@@ -8125,6 +9814,26 @@ packages:
     - liblzma >=5.8.3,<6.0a0
   size: 112995
   timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+  sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+  md5: 75d211f04ac87506f1f43420712a69fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.34.8,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 649974
+  timestamp: 1787177490105
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
   sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
   md5: 2a45e7f8af083626f009645a6481f12d
@@ -8329,6 +10038,22 @@ packages:
     - libprotobuf >=7.35.1,<7.35.2.0a0
   size: 3774596
   timestamp: 1783168720126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+  sha256: 09e8effdc89bc5d021349318d32b85594f5b8d8e3ab8f90a85b81f8fe695a566
+  md5: 77be60417aa572afcb48cbe0f967401d
+  depends:
+  - libstdcxx >=15
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libpsl >=0.23.1,<0.24.0a0
+  size: 72519
+  timestamp: 1786970753847
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hf670292_0.conda
   sha256: 2e6405feb59e3f40a5a4641dfa73afda158046893aa73d478e23415e18997ece
   md5: c8217f5bdd5b018087bdea081912cda5
@@ -8377,6 +10102,34 @@ packages:
     - libsodium >=1.0.22,<1.0.23.0a0
   size: 269272
   timestamp: 1779163468406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-hebe6cf0_2.conda
+  sha256: 7454c6a7cf27033757f2895bc5e3941fe27604506edd62cf6bc00e50ab015a43
+  md5: 42c585f153c17b790cd01f01553d24a1
+  depends:
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  license: ISC
+  purls: []
+  run_exports:
+    weak:
+    - libsodium >=1.0.22,<1.0.23.0a0
+  size: 269985
+  timestamp: 1787225747011
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  md5: e72bbec309c2b0f37823ee7d4fabfcd3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 974348
+  timestamp: 1787051145557
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
   sha256: 72023efc207fe681e26b65fc9d668062cf0b4f0eacf3431e6eb099b95c1f2efd
   md5: df088a279cd5e6fd2790b4c196434da1
@@ -8422,6 +10175,20 @@ packages:
   run_exports: {}
   size: 6631744
   timestamp: 1785375462643
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_2.conda
+  sha256: af96a5fcf1ce0659d257ababc1b8d0bbb698250e8140c6b8352f60d3be075392
+  md5: d4883ac53b4074ca17e5c567bb8008f1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 16.1.0 ha9f2e26_2
+  constrains:
+  - libstdcxx-ng ==16.1.0=*_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 6630263
+  timestamp: 1787165375778
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
   sha256: 2876ca4463d1b394eb969ce4a84d1620aa63fb8202a6397837d1e45ec76c1208
   md5: c94f06123272d8e129d4acf3a25ffb35
@@ -8435,6 +10202,19 @@ packages:
     - libstdcxx
   size: 28253
   timestamp: 1785375500257
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_2.conda
+  sha256: f096fb41c6ad3ef41c479ebce001329a531e0862c9a88979203597b610383158
+  md5: 8531022ddd724933da9dc3d426a5ad9d
+  depends:
+  - libstdcxx 16.1.0 h934c35e_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - libstdcxx
+  size: 28339
+  timestamp: 1787165409751
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
   sha256: 2293884d59cf0436c37fc0a4bad71011a8de2a6913610d1c701a7703377c1f75
   md5: ea0da9c20bbb221b530810c3c68bbe62
@@ -8626,6 +10406,23 @@ packages:
     - libxcb >=1.17.0,<2.0a0
   size: 395888
   timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_1.conda
+  sha256: ce25a1efa85a78a3ce3b16721d9c36153814adbf2fb004a15f72ec69894b4cb1
+  md5: 64e856c420205b009da26471d3ac161d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
+  size: 397355
+  timestamp: 1787077466600
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
   sha256: f7e9292dd219a6435bbb1223da9586c3e70d66d169c5a92f08db3f2127df04e9
   md5: f7a7ff5a6ab331e037abd34f379a631d
@@ -8639,6 +10436,25 @@ packages:
     - libxcrypt >=4.4.38
   size: 101957
   timestamp: 1785887123445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-h51789e4_1.conda
+  sha256: d44878d396713ccf3b355df617f61c40a1442fffcf134392bc6ce0e6c2219369
+  md5: f888787e0eab7a8076a67d197e155ffc
+  depends:
+  - xkeyboard-config
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: MIT AND MIT-open-group AND HPND AND HPND-sell-variant AND ISC
+  purls: []
+  run_exports:
+    weak:
+    - libxkbcommon >=1.13.2,<2.0a0
+  size: 942571
+  timestamp: 1787178780572
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
   sha256: 046f2ff4acebd8729fac03e99c8c307dfb48b6a32894ba8c11576e78f6e76e43
   md5: dc8b067e22b414172bedd8e3f03f3c95
@@ -8764,6 +10580,24 @@ packages:
   run_exports: {}
   size: 1520490
   timestamp: 1779194842174
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.1.2-py310h04e47aa_0.conda
+  sha256: d2c3cf66751b8998947313fa99ca9f1d18fdd6160a5d80e24e6775d6947e0880
+  md5: 0b432db9f6666c45127dd041d130ea01
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libxslt >=1.1.43,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause and MIT-CMU
+  purls:
+  - pkg:pypi/lxml?source=hash-mapping
+  run_exports: {}
+  size: 1528460
+  timestamp: 1787133188792
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-hee9eb32_2.conda
   sha256: b8c0e930183e6b7f83cd35ace102f2b8c2f0faae41dc05255dc72f247dfc556a
   md5: e38a3253d72ab07d471483f24947e2a2
@@ -9355,6 +11189,32 @@ packages:
   run_exports: {}
   size: 13697155
   timestamp: 1778933871748
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.2-py310ha8dd31c_0.conda
+  sha256: deeb1b4520afa393ddbf026605f8912cad0488fda52dba9882761df0e1f4682a
+  md5: ed28342dc9b204e7ebe980eff193fb91
+  depends:
+  - python
+  - qt6-main 6.11.2.*
+  - libgcc >=15
+  - libstdcxx >=15
+  - __glibc >=2.17,<3.0.a0
+  - libxslt >=1.1.43,<2.0a0
+  - qt6-main >=6.11.2,<7.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - python_abi 3.10.* *_cp310
+  - libvulkan-loader >=1.4.357.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libclang13 >=22.1.8
+  license: LGPL-3.0-only
+  purls:
+  - pkg:pypi/pyside6?source=hash-mapping
+  - pkg:pypi/shiboken6?source=hash-mapping
+  run_exports: {}
+  size: 13822358
+  timestamp: 1787219439408
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
   build_number: 1
   sha256: c15d8585b7a52fdb734bd16dbdcae4b81ed59268862d3a2588eb8ed69c8cbc52
@@ -9586,6 +11446,82 @@ packages:
     - qt6-main >=6.11.1,<7.0a0
   size: 60185421
   timestamp: 1780593127053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+  sha256: 00d9bc98d04aeeab6f698ca7fe9d666b157ab39b52cad1af0fa346522705668d
+  md5: 2ff98660281d1c6bfebda5bffa52cc89
+  depends:
+  - libxcb
+  - xcb-util
+  - xcb-util-wm
+  - xcb-util-keysyms
+  - xcb-util-image
+  - xcb-util-renderutil
+  - xcb-util-cursor
+  - libgl-devel
+  - libegl-devel
+  - libgcc >=15
+  - libstdcxx >=15
+  - __glibc >=2.17,<3.0.a0
+  - libglib >=2.88.3,<3.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libvulkan-loader >=1.4.357.0,<2.0a0
+  - wayland >=1.26.0,<2.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  - alsa-lib >=1.2.16.1,<1.3.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libtiff >=4.7.2,<4.8.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - dbus >=1.16.2,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - double-conversion >=3.4.0,<3.5.0a0
+  - icu >=78.3,<79.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.7,<4.0a0
+  - xorg-libxcomposite >=0.4.7,<1.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpq >=18.6,<19.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - libharfbuzz >=14.3.1
+  - fontconfig >=2.18.3,<3.0a0
+  - fonts-conda-ecosystem
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xcb-util-cursor >=0.1.6,<0.2.0a0
+  - libxkbcommon >=1.13.2,<2.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libdrm >=2.4.129,<2.5.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  constrains:
+  - qt ==6.11.2
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  run_exports:
+    weak:
+    - qt6-main >=6.11.2,<7.0a0
+  size: 60888449
+  timestamp: 1787048975419
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-63.0-h192683f_1.conda
   sha256: f0931894c751b22be09d7c976343a2957a14a59cfe0db04d916d1b93bd66ffcf
   md5: da47d3251c0f0d16b2801afe5a77b532
@@ -9633,6 +11569,21 @@ packages:
     - readline >=8.3,<9.0a0
   size: 345073
   timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  md5: 69c01c781e7c8190bbdaf79e3848c5ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - ncurses >=6.6,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 348899
+  timestamp: 1787033801506
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py310hd8f68c5_0.conda
   sha256: ac1132a9344c77e19bbbdb966668cf73a861ceec7b075858a52c8e961fb8ea9d
   md5: 61ff3f8e00c63bb66903636d0197e962
@@ -9789,6 +11740,24 @@ packages:
     - libsqlite >=3.53.4,<4.0a0
   size: 206694
   timestamp: 1785016118388
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.4-h9ffa6c4_1.conda
+  sha256: b01812eff4e950a73933cb3dc14647a97ee377c7fab4858495b80a749ebfbf8b
+  md5: d42b24574925bfa3167efb3571c905ad
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=15
+  - libsqlite 3.53.4 h13e7031_1
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - readline >=8.3,<9.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 205686
+  timestamp: 1787051150973
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
   sha256: 30cb9355c2fefc20ff1a3d6566b9714d5614086a2524c07721fc344eb20515ae
   md5: 7073b15f9364ebc118998601ac6ca6a6
@@ -10030,6 +11999,21 @@ packages:
     - xorg-libx11 >=1.8.13,<2.0a0
   size: 839652
   timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+  sha256: 68053eebfa9f0d91666786c8fb5839d989aa9b869add92cb8815228bb2d7302c
+  md5: 8c282bbe4808a3cc80a5c98e9aec1cfc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libx11 >=1.8.13,<2.0a0
+  size: 839578
+  timestamp: 1787087012372
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
   sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
   md5: f06ef439c280a5f90b8bf62355008dbc
@@ -10108,6 +12092,21 @@ packages:
     - xorg-libxdmcp >=1.1.5,<2.0a0
   size: 21120
   timestamp: 1786381006369
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+  sha256: aa9bbe8b278aacc194e280ff5037f9f9a1f2c5b33ed97de8e7f01cfbe90dda43
+  md5: e5b6b28536b81b3f4cb20db4668a4642
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libxext >=1.3.7,<2.0a0
+  size: 53124
+  timestamp: 1787100841900
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
   sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
   md5: 34e54f03dfea3e7a2dcf1453a85f1085
@@ -10172,6 +12171,21 @@ packages:
     - xorg-libxrandr >=1.5.5,<2.0a0
   size: 30456
   timestamp: 1769445263457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+  sha256: 6901f91d398811e4ec89d7e20a69abac02a7bfebfaf073338b7ea3d1a99685b7
+  md5: e470d224a7a5be1b1d021bded7abb536
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libxrender >=0.9.12,<0.10.0a0
+  size: 34645
+  timestamp: 1787100191192
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
   sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
   md5: 96d57aba173e878a2089d5638016dc5e
@@ -10246,6 +12260,19 @@ packages:
     - yaml >=0.2.5,<0.3.0a0
   size: 85189
   timestamp: 1753484064210
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-hebe6cf0_3.conda
+  sha256: d164dfa75ecd538f6fd68765defcc06aa875bc697b9b215362d79a2a73125dd0
+  md5: e741576fb8f89821ac7c1c537322a33d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: MIT
+  purls: []
+  run_exports:
+    weak:
+    - yaml >=0.2.5,<0.3.0a0
+  size: 84936
+  timestamp: 1787228426393
 - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.24.5-py310h3406613_0.conda
   sha256: 8964c7cd752622e39dd159ee1601ced790ea3114ae9fa2c6b62902a26ad47c1e
   md5: 46f4919b18d69a028c6bc5b5a0317b4f
@@ -10345,6 +12372,27 @@ packages:
   run_exports: {}
   size: 85098
   timestamp: 1784282277153
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.9.0-pyhcf101f3_0.conda
+  sha256: 6308217aef5820c5f1c1e564852de28087fb6117b8a1bbeaae05ed169f0b04da
+  md5: 0df9b1b245c84f7d16278806a1a0ad67
+  depends:
+  - python >=3.10
+  - aiohttp >=3.14.0,<4.0.0
+  - aioitertools >=0.5.1,<1.0.0
+  - botocore >=1.43.3,<1.43.57
+  - python-dateutil >=2.1,<3.0.0
+  - jmespath >=0.7.1,<2.0.0
+  - multidict >=6.0.0,<7.0.0
+  - wrapt >=1.10.10,<3.0.0
+  - typing_extensions >=4.14.0,<5.0.0
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/aiobotocore?source=compressed-mapping
+  run_exports: {}
+  size: 93162
+  timestamp: 1787053079193
 - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
   sha256: 5ef589e5fd3736439781a9d48e68ce1e723b7081a471c02169908198eba4f448
   md5: e51e09bf3b91c62b7461a9f94e92c2c9
@@ -10591,6 +12639,21 @@ packages:
   run_exports: {}
   size: 88728
   timestamp: 1783963519235
+- conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.43.56-pyhd8ed1ab_0.conda
+  sha256: c7c455ea506f7f406f37a9eb15768dde7d26419c00934e36fee0eecd83e44c93
+  md5: 33bcd4d833dd2f1d7a0e1ac8df60e6d9
+  depends:
+  - botocore >=1.43.56,<1.44.0
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10
+  - s3transfer >=0.19.0,<0.20.0
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/boto3?source=hash-mapping
+  run_exports: {}
+  size: 88669
+  timestamp: 1785004260144
 - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.46-pyhd8ed1ab_0.conda
   sha256: a12cc129c8a4cfb9025bb89a53dd4faac464170d7d24f308e00eb8753904aba1
   md5: d8760823ce858e6c8d74f56e5ffab734
@@ -10606,6 +12669,21 @@ packages:
   run_exports: {}
   size: 8864109
   timestamp: 1783942209492
+- conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.56-pyhd8ed1ab_0.conda
+  sha256: de52faa61323fe05733fbab181d2b44a58f920fb9aacb817f72001ba422c7f28
+  md5: 07768d0daf163ae593054123a7644d03
+  depends:
+  - jmespath >=0.7.1,<2.0.0
+  - python >=3.10
+  - python-dateutil >=2.1,<3.0.0
+  - urllib3 >=1.25.4,!=2.2.0,<3
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/botocore?source=hash-mapping
+  run_exports: {}
+  size: 8828101
+  timestamp: 1784970328142
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
   sha256: 95e8e74062a5fe5f870ac8c90302b6e89945165fdaed7810606e84ddee6aac12
   md5: e27d2ac27b096dc51fedfcf775a53f9b
@@ -10672,6 +12750,18 @@ packages:
   run_exports: {}
   size: 63942
   timestamp: 1786631964278
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+  sha256: cb60ef3e0631c8bacb4f7057196dee4496091a22baa3bb4b9bccb12c7e1c921b
+  md5: e0ac3accc64e23e40969d660e5f58ac8
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/charset-normalizer?source=compressed-mapping
+  run_exports: {}
+  size: 64487
+  timestamp: 1786835648298
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
   sha256: 5b5c96afdd801dd9c3b78ebc2cd9a9f3ce34186257415d394dde1aa8468aa3c0
   md5: 8a0d65027e25e367f9f1754f0604e8de
@@ -11006,6 +13096,19 @@ packages:
   run_exports: {}
   size: 163869
   timestamp: 1781620148226
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+  sha256: 1c35a59c1545ad0fdaddf1fbde7bcfa6ef41a8d68c3a2b0b4a291be00676163e
+  md5: a39ae05027e9b707742e41b30d296b75
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=compressed-mapping
+  run_exports: {}
+  size: 177433
+  timestamp: 1787059857580
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
   sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
   md5: ffc17e785d64e12fc311af9184221839
@@ -11184,6 +13287,23 @@ packages:
   run_exports: {}
   size: 114376
   timestamp: 1762040524661
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.9-pyhd8ed1ab_0.conda
+  sha256: c391fe12c24fce4f8380f44ebdfb62a5ecdbf0ee168e7db7ea9baf3527eec003
+  md5: 1efaf89bb5d9a6ff2ce5f84d25678f53
+  depends:
+  - comm >=0.1.3
+  - ipython >=6.1.0
+  - jupyterlab_widgets >=3.0.17,<3.1.0
+  - python >=3.10
+  - traitlets >=4.3.1
+  - widgetsnbextension >=4.0.16,<4.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/ipywidgets?source=compressed-mapping
+  run_exports: {}
+  size: 115707
+  timestamp: 1787052940568
 - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
   sha256: 08e838d29c134a7684bca0468401d26840f41c92267c4126d7b43a6b533b0aed
   md5: 0b0154421989637d424ccf0f104be51a
@@ -11596,6 +13716,21 @@ packages:
   run_exports: {}
   size: 216779
   timestamp: 1762267481404
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.17-pyhcf101f3_0.conda
+  sha256: 697c4a5b4771e8fbd5a9bbb614899982c7e586eafaf123c210f9d1794436f00a
+  md5: 1fb3f0d175d6e92f56139fb46a17aa2d
+  depends:
+  - python >=3.10
+  - python
+  constrains:
+  - jupyterlab >=4,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/jupyterlab-widgets?source=compressed-mapping
+  run_exports: {}
+  size: 219589
+  timestamp: 1787045328396
 - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
   sha256: 49570840fb15f5df5d4b4464db8ee43a6d643031a2bc70ef52120a52e3809699
   md5: 9b965c999135d43a3d0f7bd7d024e26a
@@ -11735,6 +13870,23 @@ packages:
   run_exports: {}
   size: 107583
   timestamp: 1786372859684
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.11.1-pyhcf101f3_0.conda
+  sha256: d85d76827ff732e1639f50f45e4d7d3387a27abd857b194dcbb5bb4166c2a7c2
+  md5: 2fbbf92e1173ae024f0b12759c1e64a1
+  depends:
+  - jsonschema >=2.6
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.10
+  - python-fastjsonschema >=2.15
+  - traitlets >=5.1
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/nbformat?source=compressed-mapping
+  run_exports: {}
+  size: 107750
+  timestamp: 1787133512599
 - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
   sha256: e6768ceef038f4d7e083de7e393f5dd7d672b937e2bda570b740f6399b686689
   md5: fcd832bfd4749e9b246112b6894f97fc
@@ -12066,6 +14218,19 @@ packages:
   run_exports: {}
   size: 893031
   timestamp: 1774796815820
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+  sha256: f5f015ff1bc3e1b7fc08eee096b1865234189ae0b82bebdb86a5369116e42fa0
+  md5: 2882dee445dfa45b0c5afce3ffb7730a
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=compressed-mapping
+  run_exports: {}
+  size: 959376
+  timestamp: 1786995678795
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
   sha256: 417fba4783e528ee732afa82999300859b065dc59927344b4859c64aae7182de
   md5: 3687cc0b82a8b4c17e1f0eb7e47163d5
@@ -12168,6 +14333,19 @@ packages:
   run_exports: {}
   size: 252180
   timestamp: 1785242896823
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.22.2-pyhcf101f3_0.conda
+  sha256: fc4a704822df22defce49d0fb811fdc036a1fd3b579aeaa601228e9cfd198b3d
+  md5: aa75b7f096d17621bc307b3025b29461
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/fastjsonschema?source=compressed-mapping
+  run_exports: {}
+  size: 254446
+  timestamp: 1786892280524
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-4.1.0-pyhd8ed1ab_0.conda
   sha256: a0dfe07d0bc1d8c47a38b79ad4a8eb1bc7b86fb33ee5293ebb45dfdc46191f4e
   md5: 982ed0cbfc0fe09f25861e3d111e9717
@@ -12181,6 +14359,19 @@ packages:
   run_exports: {}
   size: 19249
   timestamp: 1781036004580
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-4.2.0-pyhd8ed1ab_0.conda
+  sha256: 4f8ecadbd9d282b0208d6e84640573fcb6ab462307d737eedd28341964e18cc6
+  md5: e5407c82510aab6a4baa31fcd4249655
+  depends:
+  - python >=3.10
+  - typing_extensions
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/python-json-logger?source=compressed-mapping
+  run_exports: {}
+  size: 19367
+  timestamp: 1786872772907
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.3-pyhd8ed1ab_0.conda
   sha256: 3f05db78cf8be33cf6dbc469664b8e3a01f3980d61d6d6bef48669b171896d8a
   md5: eefc8d916bd2e708d76d40398ef9a1ee
@@ -12705,6 +14896,18 @@ packages:
   run_exports: {}
   size: 889195
   timestamp: 1762040404362
+- conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.16-pyhd8ed1ab_0.conda
+  sha256: bd909d9845ff269f5487a83654d6b8fe220c73148c47d602f4ee9e1283829212
+  md5: 4e3aff9f40afb392477584e6a1a45b6f
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/widgetsnbextension?source=compressed-mapping
+  run_exports: {}
+  size: 901988
+  timestamp: 1787044664327
 - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
   sha256: 93807369ab91f230cf9e6e2a237eaa812492fe00face5b38068735858fba954f
   md5: 46e441ba871f524e2b067929da3051c2
@@ -13093,6 +15296,20 @@ packages:
   run_exports: {}
   size: 192836
   timestamp: 1781450866088
+- conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.7.0-py310h80e3c0f_0.conda
+  sha256: 7245443a38a9eadca1410e1d18dc0d2bd02408a2fff3ec251e27f89e3ca8d11b
+  md5: 1bc00c1273ebe31e43eb8ff75bf0a405
+  depends:
+  - python
+  - __osx >=11.0
+  - python_abi 3.10.* *_cp310
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  purls:
+  - pkg:pypi/backports-zstd?source=hash-mapping
+  run_exports: {}
+  size: 191522
+  timestamp: 1786861473606
 - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.2.0-ha9642f3_3.conda
   sha256: 90541ac38b6ee2efc3fda40b97b05157e2cd51ccc5623b7a04553801a74935e7
   md5: 716ed87c4de517083437f9ef23a852c6
@@ -13169,6 +15386,19 @@ packages:
     - c-ares >=1.34.8,<2.0a0
   size: 205386
   timestamp: 1786116708158
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+  sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+  md5: 925ff9ab74f4b9262a28842766e9e7b1
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.8,<2.0a0
+  size: 205559
+  timestamp: 1787170041830
 - conda: https://conda.anaconda.org/conda-forge/osx-64/cartopy-0.25.0-np2py310hf83fa34_3.conda
   sha256: e5f2f71ff46227761db4c2d9c4002444026ecd66b17bcdf1cdcce44fc3db40e3
   md5: 2e0308352dcc9c9dd36379d7ede8d78f
@@ -13461,6 +15691,24 @@ packages:
     - libabseil =*=cxx17*
   size: 1271334
   timestamp: 1780525130242
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20260526.0-cxx17_h6e8c311_2.conda
+  sha256: d077578fc3a684f7ad246f87622a3a9702d429dd14e690a1bbfc6644480ebb92
+  md5: 02e11f8c54cef4f022bc1a086d5f7c2f
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  constrains:
+  - abseil-cpp =20260526.0
+  - libabseil-static =20260526.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - libabseil >=20260526.0,<20260527.0a0
+    - libabseil =*=cxx17*
+  size: 1269390
+  timestamp: 1787217935603
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-25.0.0-he333e4a_4_cpu.conda
   build_number: 4
   sha256: 278fa5130549faa6b3215ca23b0c09b631feb955d8b233d5dd1ce64e20f77736
@@ -13872,6 +16120,20 @@ packages:
   run_exports: {}
   size: 389139
   timestamp: 1785378471977
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.1.0-h13771c8_2.conda
+  sha256: 88e373662ddcc97f1be8f9ccac9e7f6e1c939e7d0b5e4e9744107e43d8a09f3f
+  md5: 25415ab183631bd7bbe7ab56906f7ab9
+  depends:
+  - _openmp_mutex
+  constrains:
+  - libgcc-ng ==16.1.0=*_2
+  - libgomp 16.1.0 2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 389917
+  timestamp: 1787168765362
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.1.0-h7e5c614_1.conda
   sha256: a34b6224081d6a34cb06cae813f6fe06ce5d1d5b9049e4f172b5f684a81c1978
   md5: 0fcefb3d06bd72bd61435fd2fae351b6
@@ -13885,6 +16147,19 @@ packages:
   run_exports: {}
   size: 98568
   timestamp: 1785378652809
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.1.0-h7e5c614_2.conda
+  sha256: 2cb425ed093f125a2812b128be49a777f7a1e4c9c1ec6871c411bbd694e342a4
+  md5: 70e39bb4fd93297663ab1477daa5d17c
+  depends:
+  - libgfortran5 16.1.0 h70d9f54_2
+  constrains:
+  - libgfortran-ng ==16.1.0=*_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 98758
+  timestamp: 1787169138385
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.1.0-h70d9f54_1.conda
   sha256: 66404e44a45fdc6eb56116b82bda2b44a812fbea30a55be8991dfdef6046c59d
   md5: dcd171b89443b4302929ea8081a32fc9
@@ -13898,6 +16173,19 @@ packages:
   run_exports: {}
   size: 1032731
   timestamp: 1785378481811
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.1.0-h70d9f54_2.conda
+  sha256: 3fbe1dd14ccc751e9cb097e96683cb68efd53e95f39912d5c2270efa1942fd61
+  md5: 50d3c9ba4f58b09195f04816452440f1
+  depends:
+  - libgcc >=16.1.0
+  constrains:
+  - libgfortran 16.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 1032733
+  timestamp: 1787168781397
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.8.0-he806f76_0.conda
   sha256: 03a2818d1ce4da59ea354da2a5a0c61d755356d02a1bf93becd0972dafff98e6
   md5: 9b764c99f823de24d364cf7a91a7f3f0
@@ -13981,6 +16269,18 @@ packages:
     - libhwloc >=2.13.0,<2.13.1.0a0
   size: 2363468
   timestamp: 1770954013361
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+  sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+  md5: 9fd2f77288f43e462ccc6b0e5f018c89
+  depends:
+  - __osx >=11.0
+  license: LGPL-2.1-only
+  purls: []
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
+  size: 736150
+  timestamp: 1787034707041
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
   sha256: a1c8cecdf9966921e13f0ae921309a1f415dfbd2b791f2117cf7e8f5e61a48b6
   md5: 210a85a1119f97ea7887188d176db135
@@ -14059,6 +16359,25 @@ packages:
     - liblzma >=5.8.3,<6.0a0
   size: 104919
   timestamp: 1786349094608
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+  sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+  md5: b7c605bed8006cdeb822dd7de6ac87c7
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.8,<2.0a0
+  - libcxx >=21
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 598607
+  timestamp: 1787178086085
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
   sha256: 899551e16aac9dfb85bfc2fd98b655f4d1b7fea45720ec04ccb93d95b4d24798
   md5: dba4c95e2fe24adcae4b77ebf33559ae
@@ -14210,6 +16529,18 @@ packages:
     - libsodium >=1.0.22,<1.0.23.0a0
   size: 281370
   timestamp: 1779164249823
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.22-had63097_2.conda
+  sha256: 37f37af34a44832a7b7e19d8b220567aa599384dcda0b988f7f13297f4cb5441
+  md5: ca807adc2d3945ae2f6b9f12fcf8dd6b
+  depends:
+  - __osx >=11.0
+  license: ISC
+  purls: []
+  run_exports:
+    weak:
+    - libsodium >=1.0.22,<1.0.23.0a0
+  size: 283497
+  timestamp: 1787226015597
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-h77d7759_0.conda
   sha256: 5725d44a17d196adba9798a5fd9f692b7039a827cd6145556a072a80e1931c49
   md5: 993009426e1d3aa90eed155171bd59d8
@@ -14223,6 +16554,19 @@ packages:
     - libsqlite >=3.53.4,<4.0a0
   size: 1008531
   timestamp: 1785016345740
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+  sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+  md5: 254c302876eacc77a4682b3fa6f72385
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 1008994
+  timestamp: 1787051932723
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hd53bb72_1.conda
   sha256: ed0db46844a548f4ca57dad0b3abb92b37050d7f75ab1ef08fbed9d23f06b2de
   md5: cb57b979974ef5b8a4526a8e5c8195b9
@@ -14347,6 +16691,22 @@ packages:
     - libwebp-base >=1.6.0,<2.0a0
   size: 364823
   timestamp: 1785954881871
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-h2478c6c_1.conda
+  sha256: f19550d311365ea8541424daafcad13a5d0259e905a1faad3caeae1eb659d271
+  md5: f964ec5d9d2aee3639c5797b0f801164
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
+  size: 325124
+  timestamp: 1787078047035
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
   sha256: 8896cd5deff6f57d102734f3e672bc17120613647288f9122bec69098e839af7
   md5: bbeca862892e2898bdb45792a61c4afc
@@ -14463,6 +16823,23 @@ packages:
   run_exports: {}
   size: 1345728
   timestamp: 1779195948824
+- conda: https://conda.anaconda.org/conda-forge/osx-64/lxml-6.1.2-py310hc6132bc_0.conda
+  sha256: eb2ae2bcf1e91011e2aed0832b08eca754a0964324696ca2c350d35b93bd4c25
+  md5: 23e9d33589640e4d93a7c8bcd14a5048
+  depends:
+  - __osx >=11.0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libxslt >=1.1.43,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause and MIT-CMU
+  purls:
+  - pkg:pypi/lxml?source=hash-mapping
+  run_exports: {}
+  size: 1300204
+  timestamp: 1787133490318
 - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-hc569e58_2.conda
   sha256: 97fedceb365f882790f37cf40bbfa89a67cdfa0d9e41e71a015d123d15b50433
   md5: 40a2f8f02e39f9ca56006f35510627f4
@@ -15138,6 +17515,20 @@ packages:
     - re2
   size: 27323
   timestamp: 1781313020322
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+  sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+  md5: 434eb49340f57827ef7ca3bb21f77c32
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.6,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 319279
+  timestamp: 1787034454836
 - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
   sha256: 4614af680aa0920e82b953fece85a03007e0719c3399f13d7de64176874b80d5
   md5: eefd65452dfe7cce476a519bece46704
@@ -15297,6 +17688,22 @@ packages:
     - libsqlite >=3.53.4,<4.0a0
   size: 192770
   timestamp: 1785016359926
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.53.4-hdea7a7b_1.conda
+  sha256: eada66c9946b1feaff5c50b63902305836f09532a71ccf6461e73dc75b28018e
+  md5: 9df7defaa7ca556b72dfe386417c5829
+  depends:
+  - __osx >=11.0
+  - libsqlite 3.53.4 ha5db789_1
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - readline >=8.3,<9.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 188237
+  timestamp: 1787051955441
 - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.13.0-hc1436ee_6.conda
   sha256: 7585c40ffd1b2346f31fd857a9882a4e5558e35d3f63640d925fe50a80bf06d6
   md5: b781a4099393cffae4835ab4c07e664a
@@ -15404,6 +17811,18 @@ packages:
     - yaml >=0.2.5,<0.3.0a0
   size: 79419
   timestamp: 1753484072608
+- conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-had63097_3.conda
+  sha256: b63a29a5e4968b28c8403525549fd662de8ff5863e6287f89cfaac7d1d688ea0
+  md5: 9b30f8e851965211d981aca9c9bd1196
+  depends:
+  - __osx >=11.0
+  license: MIT
+  purls: []
+  run_exports:
+    weak:
+    - yaml >=0.2.5,<0.3.0a0
+  size: 75645
+  timestamp: 1787228502493
 - conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.24.5-py310h399bfa0_0.conda
   sha256: 4421619e5cd4dbe69b93649890ddd20e029db1bd7027539f7ec7f32bde872f39
   md5: 792c1313ba787a4281b6316c560ce0ca
@@ -15844,6 +18263,20 @@ packages:
   run_exports: {}
   size: 193029
   timestamp: 1781450816995
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.7.0-py310h94e62c7_0.conda
+  sha256: 0ee568f8fcca5008adc6c7d1f4384e09dc81a4408f782c7ceb97dbf13a055059
+  md5: 22375e7cb970d4eb0f7f6776f962bc21
+  depends:
+  - python
+  - __osx >=11.0
+  - python_abi 3.10.* *_cp310
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  purls:
+  - pkg:pypi/backports-zstd?source=hash-mapping
+  run_exports: {}
+  size: 191145
+  timestamp: 1786861430225
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.2.0-hf00d406_3.conda
   sha256: 7050e1b11876219bd0df375ef3d83fd00f94fb4e13c1ffb21dede0c506893079
   md5: aa7df8174ee3b34a5ad8a3160429db68
@@ -15920,6 +18353,19 @@ packages:
     - c-ares >=1.34.8,<2.0a0
   size: 197274
   timestamp: 1786116660078
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+  sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+  md5: 4cc01a374215de38387d45e19c8c5c9c
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.8,<2.0a0
+  size: 197819
+  timestamp: 1787169996553
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cartopy-0.25.0-np2py310hd9bf50c_3.conda
   sha256: b86beb4821d8c16b658bb06cb6b1906cc59fe8e21c63554e51ddc84fc5432f9a
   md5: f7f039126e52cc649ae14d144f57e1fc
@@ -16232,6 +18678,24 @@ packages:
     - libabseil =*=cxx17*
   size: 1273408
   timestamp: 1780524599788
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260526.0-cxx17_h4c27e2a_2.conda
+  sha256: d9c62dae9d8f5bebadf72fcf369c00cc353183cb2521f9fffbf4c2f70b58bef9
+  md5: 2aa5e7dc7b5d218908effd2a8c70a8a8
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  constrains:
+  - abseil-cpp =20260526.0
+  - libabseil-static =20260526.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - libabseil >=20260526.0,<20260527.0a0
+    - libabseil =*=cxx17*
+  size: 1277537
+  timestamp: 1787217005681
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-25.0.0-haaed7fe_4_cpu.conda
   build_number: 4
   sha256: 3c289bab2a8c4be0ef86363c97c5532dbcc289708b8523d6a3cfef35a2dd0b9b
@@ -16453,6 +18917,26 @@ packages:
     - libcrc32c >=1.1.2,<1.2.0a0
   size: 18765
   timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-h6651222_5.conda
+  sha256: 59dd850def9473e7f63ed72afc750bba9670316f279c0bd409572cd47569ed5f
+  md5: 5ae67c128838b686894b4a3aef015c29
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libpsl >=0.23.1,<0.24.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 409852
+  timestamp: 1787183686192
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-hf618e03_4.conda
   sha256: d25be36712d7f854a5f93513b9fbf1b0ee3219975b7fef4a3ee071b021b10167
   md5: 66cf9c5003ee81ecdb0dc9f9df17bbe5
@@ -16602,6 +19086,20 @@ packages:
   run_exports: {}
   size: 364162
   timestamp: 1785374452947
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.1.0-h3cf6597_2.conda
+  sha256: 72ad51807f267a409ed4ef82b701b23e8dc13989a873c0b9ae4995ca41365a12
+  md5: 66681fa4c888def48bcec00e7f4a4a5b
+  depends:
+  - _openmp_mutex
+  constrains:
+  - libgcc-ng ==16.1.0=*_2
+  - libgomp 16.1.0 2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 363865
+  timestamp: 1787164250817
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.1.0-h07b0088_1.conda
   sha256: d7c6dd601dbbde495ab213a76d690b2fec19455d26c595ec0257cfde3e80166b
   md5: d6f10dbb9c5830f540904c91ea5b252a
@@ -16615,6 +19113,19 @@ packages:
   run_exports: {}
   size: 98528
   timestamp: 1785374566402
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.1.0-h07b0088_2.conda
+  sha256: 31d471423a1d09727778756e0846c2ec928d2cf38d3801be35d5c2487808549c
+  md5: be6243e0464580e5ef89d61f314c8393
+  depends:
+  - libgfortran5 16.1.0 h32cdfcc_2
+  constrains:
+  - libgfortran-ng ==16.1.0=*_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 98565
+  timestamp: 1787164344964
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.1.0-h32cdfcc_1.conda
   sha256: 3e8cb79a421e0c350566717febdba9079574cbbe204591b4fd4b4081ea89cb92
   md5: c1c10ea48f95054aa9b93c2315a0a74a
@@ -16628,6 +19139,19 @@ packages:
   run_exports: {}
   size: 556657
   timestamp: 1785374459225
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.1.0-h32cdfcc_2.conda
+  sha256: a55a80209042b8d052cca044ba0a65b100af4f757bdb2eec249d5813b8e456e6
+  md5: c2b2f4052071315e542c5dd9e3e541aa
+  depends:
+  - libgcc >=16.1.0
+  constrains:
+  - libgfortran 16.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 556436
+  timestamp: 1787164256762
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.8.0-ha595bda_0.conda
   sha256: a48050bcf3827e0fc10de5a7d251760b8b84011f3aeea23ae18b5e0ce25aff19
   md5: 4f34ca73f16b37fae583ce16c48b5492
@@ -16707,6 +19231,18 @@ packages:
     - libiconv >=1.18,<2.0a0
   size: 750379
   timestamp: 1754909073836
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+  sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+  md5: 17f4744c0873e9f77ac9b5cd0a27c187
+  depends:
+  - __osx >=11.0
+  license: LGPL-2.1-only
+  purls: []
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
+  size: 750816
+  timestamp: 1787033961086
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
   sha256: 05006418f9392c9b723e8428808db106de0350a497832f95f921b85ff1072310
   md5: b2f8c8e5a7651a1d7c05404c3a159517
@@ -16753,6 +19289,25 @@ packages:
     - liblzma >=5.8.3,<6.0a0
   size: 91720
   timestamp: 1786348695846
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+  sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+  md5: ac9902dcbe0417f50cf95ab2bde062fa
+  depends:
+  - __osx >=11.0
+  - c-ares >=1.34.8,<2.0a0
+  - libcxx >=21
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libnghttp2 >=1.68.1,<2.0a0
+  size: 567024
+  timestamp: 1787177422467
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
   sha256: 2bc7bc3978066f2c274ebcbf711850cc9ab92e023e433b9631958a098d11e10a
   md5: 6ea18834adbc3b33df9bd9fb45eaf95b
@@ -16889,6 +19444,21 @@ packages:
     - libpsl >=0.23.1,<0.24.0a0
   size: 72950
   timestamp: 1786443660105
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.1-hdb0c161_1.conda
+  sha256: c8c3153df39abedf3413483f672151ad70f1adb0c06c192bdf7ec432c3616b07
+  md5: 5d270f716a2b4bc13df9af8612071b17
+  depends:
+  - __osx >=11.0
+  - libcxx >=21
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libpsl >=0.23.1,<0.24.0a0
+  size: 72673
+  timestamp: 1786970928205
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h5d15848_2.conda
   sha256: 06f49291605c379467987989ff08d44b470a23afeb690d7e078517871969bff7
   md5: b750c4f83563c7528634bdcfd28622ce
@@ -16919,6 +19489,18 @@ packages:
     - libsodium >=1.0.22,<1.0.23.0a0
   size: 247352
   timestamp: 1779164136206
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h74c22ad_2.conda
+  sha256: 1cc97c217b103145e67ae6f928d0ae11ebc56879dfd10d739539624f0de80f86
+  md5: ea78b9246e47aade6c94db52b1c9b5a4
+  depends:
+  - __osx >=11.0
+  license: ISC
+  purls: []
+  run_exports:
+    weak:
+    - libsodium >=1.0.22,<1.0.23.0a0
+  size: 249624
+  timestamp: 1787225816699
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
   sha256: 745662565e103f290e9dc4263bbd88285082f8cf699854fe2d5f1e35a4a0d326
   md5: 0e3477c0c3e718dcf2eb74ccc8f68570
@@ -16933,6 +19515,20 @@ packages:
     - libsqlite >=3.53.4,<4.0a0
   size: 929203
   timestamp: 1785016131414
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+  sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+  md5: fde96d40ebe9a9cb34e4122380189ddb
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 942754
+  timestamp: 1787051243846
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-hbf2880b_1.conda
   sha256: a056e518c3d2d09fbb1778cea80c0c95338fb24adf1a817bbf90fb484850a304
   md5: d957a8eda98c49b073e8dcfd677c127a
@@ -17058,6 +19654,22 @@ packages:
     - libwebp-base >=1.6.0,<2.0a0
   size: 294522
   timestamp: 1785955350410
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hbffa61f_1.conda
+  sha256: 81f9b4fb64d977c19474d1b5616974757aaac21d55401ea105f21022b386bd28
+  md5: 923bf656578743d064f352f0b56ee658
+  depends:
+  - __osx >=11.0
+  - pthread-stubs
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
+  size: 324264
+  timestamp: 1787077544793
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
   sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
   md5: af523aae2eca6dfa1c8eec693f5b9a79
@@ -17174,6 +19786,24 @@ packages:
   run_exports: {}
   size: 1307966
   timestamp: 1779195662247
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.1.2-py310h164b0d2_0.conda
+  sha256: 801f34e773484609ee457e6a7306fd77c738a2e9e5d03dc8f43684164d9f7a74
+  md5: a47f2e4a16685bf65e83b49ed356a462
+  depends:
+  - __osx >=11.0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libxslt >=1.1.43,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause and MIT-CMU
+  purls:
+  - pkg:pypi/lxml?source=hash-mapping
+  run_exports: {}
+  size: 1245175
+  timestamp: 1787134003245
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-hdca3b7d_2.conda
   sha256: 1887867b393eb3c2b336deaffcf228574821ea1e0dcb9ef7bf6c9f59cec40f03
   md5: d47f7f3481c6f2fcc4ed22802f61c6dd
@@ -17864,6 +20494,20 @@ packages:
     - readline >=8.3,<9.0a0
   size: 313930
   timestamp: 1765813902568
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+  sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+  md5: 9347fd56a002e6b58946831d48fe62f6
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.6,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 314395
+  timestamp: 1787033878899
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py310hf3301a5_0.conda
   sha256: 842bfe772072b6ca1ebc286e9fcbe95717d1528ec921687076d707d02d64fa61
   md5: 38645c71e72b3cc640eb508d05a28d0c
@@ -18013,6 +20657,23 @@ packages:
     - libsqlite >=3.53.4,<4.0a0
   size: 183124
   timestamp: 1785016142653
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.4-ha9f7ffe_1.conda
+  sha256: 4e0c8704a29b6c265e7bdb6508e1d4180570adcc6e031daf182578d3777fb8b1
+  md5: c144cc02c82671616e0fb4caf731bc88
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libsqlite 3.53.4 hca69786_1
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - readline >=8.3,<9.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 179903
+  timestamp: 1787051253247
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
   sha256: 47186bc7ab8d7e8bee86bbd1a917196f8c21cf63f081fc33cd6d1221af087580
   md5: 8e3cf0e455e6b54519f0b1c72c61780a
@@ -18097,6 +20758,18 @@ packages:
     - xorg-libxdmcp >=1.1.5,<2.0a0
   size: 19486
   timestamp: 1786381546642
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h74c22ad_3.conda
+  sha256: 3e78c43207502418fc5fb2317bbbefe5df8b6fc1051d90bdcd1c881c76bb4193
+  md5: 31cf6dcc138abe673c9440cd6fe6c6fe
+  depends:
+  - __osx >=11.0
+  license: MIT
+  purls: []
+  run_exports:
+    weak:
+    - yaml >=0.2.5,<0.3.0a0
+  size: 77530
+  timestamp: 1787228556857
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
   sha256: b03433b13d89f5567e828ea9f1a7d5c5d697bf374c28a4168d71e9464f5dafac
   md5: 78a0fe9e9c50d2c381e8ee47e3ea437d
@@ -18579,6 +21252,22 @@ packages:
   run_exports: {}
   size: 191413
   timestamp: 1781450841532
+- conda: https://conda.anaconda.org/conda-forge/win-64/backports.zstd-1.7.0-py310h458dff3_0.conda
+  sha256: 52d526da7ee4f3b1270f44566c3293e9f134fa1ef55ba57656fdf54e389ada45
+  md5: 67f80ef5d26d7adbfb3ce107e922334c
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.10.* *_cp310
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  purls:
+  - pkg:pypi/backports-zstd?source=hash-mapping
+  run_exports: {}
+  size: 192216
+  timestamp: 1786861405140
 - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.2.0-hc8c2fe1_3.conda
   sha256: 85e12348d058791aabd6eeb6abc1d7ab44b8f6308f91c8475f44f778f2a158af
   md5: 9eba56a007c44dc32d0b9d0a820871ea
@@ -18664,6 +21353,21 @@ packages:
     - c-ares >=1.34.8,<2.0a0
   size: 210677
   timestamp: 1786116676848
+- conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.8-h6a83c73_2.conda
+  sha256: b474e4b7f3136576c321533e340b34368a5ce671949bc1a77ef446eb94870136
+  md5: b5a0be28d048d8bbe81df51e4b750500
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.8,<2.0a0
+  size: 210803
+  timestamp: 1787169972884
 - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.4-h477c42c_1.conda
   sha256: 9ee4ad706c5d3e1c6c469785d60e3c2b263eec569be0eac7be33fbaef978bccc
   md5: 52ea1beba35b69852d210242dd20f97d
@@ -19062,6 +21766,25 @@ packages:
     - lerc >=4.2.0,<5.0a0
   size: 175297
   timestamp: 1785036247761
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20260526.0-cxx17_h04e5de1_2.conda
+  sha256: 0ba14fd35791873ef167d826f05907421455bd42c1a82a1ff84ad9e8ddddf73b
+  md5: 7cd4be232c8e6388fcf5fadc7f429dd7
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - abseil-cpp =20260526.0
+  - libabseil-static =20260526.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - libabseil >=20260526.0,<20260527.0a0
+    - libabseil =*=cxx17*
+  size: 1978839
+  timestamp: 1787217043767
 - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20260526.0-cxx17_h0eb2380_1.conda
   sha256: 103c3c49368204d26c1c4ac82cd29b6c39adf0492501b0145f6a853f0c600b3f
   md5: 50a46018a50bb1feeb4496dc98deae5b
@@ -19306,6 +22029,25 @@ packages:
     - libclang13 >=22.1.8
   size: 34918557
   timestamp: 1786527644245
+- conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-22.1.8-default_h2778606_7.conda
+  sha256: 1b074dffa40d706908cda6ccd2f4a9c50f8034eb89df4a77106c481ba4d12064
+  md5: 55fa833b10680a89d96025e922f391d1
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - llvm-openmp >=22.1.8
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  purls: []
+  run_exports:
+    weak:
+    - libclang13 >=22.1.8
+  size: 34918392
+  timestamp: 1787227694605
 - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
   sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
   md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
@@ -19368,6 +22110,25 @@ packages:
     - libcurl >=8.21.0,<9.0a0
   size: 404586
   timestamp: 1785500241182
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.21.0-hdb0ef4a_5.conda
+  sha256: bf5445ab8acfaccaf511d774f131cf0d99c5eef6b8def270e832ad26970d5011
+  md5: 50861643cbe90dc7267feb7854b8efdf
+  depends:
+  - krb5 >=1.22.2,<1.23.0a0
+  - libpsl >=0.23.1,<0.24.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 405126
+  timestamp: 1787183759927
 - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h1a1d4e4_1.conda
   sha256: af1cda21d4653f594fbef20aa4e1ff158a546902b3307ef8af9a9b44b43862d2
   md5: e4e122e124676a49eebf241399ad8393
@@ -19471,6 +22232,22 @@ packages:
   run_exports: {}
   size: 819817
   timestamp: 1785377219855
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-16.1.0-h110b43a_2.conda
+  sha256: 4457d44a3ec12e7304ca248f418ed3a1a5da7152c5627dc422e33982d71fff94
+  md5: a23cb46435dc757667ee85c060dea30a
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgcc-ng ==16.1.0=*_2
+  - libgomp 16.1.0 h8ee18e1_2
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 818811
+  timestamp: 1787166490957
 - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.88.3-he810d59_1.conda
   sha256: fd94edec4f945c82ba6b983aae2bec21dd08209a5b387fb7a713534bb3db51af
   md5: d8b3236ab45b58a0c4f4aa0a286cee13
@@ -19508,6 +22285,22 @@ packages:
     - libgomp >=16.1.0
   size: 682053
   timestamp: 1785377156260
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-16.1.0-h8ee18e1_2.conda
+  sha256: 58d07dbe9dc4f3abd6ee6beec4e875469d0734b203161d34e156eeeff6ef41bf
+  md5: 9db12c082cf914035ad95b1cea237fc8
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+    - libgomp >=16.1.0
+  size: 682073
+  timestamp: 1787166441157
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.7.0-hfe3f7e9_0.conda
   sha256: 7caeceff8cc78b6ccdf416c3950ee7c86390be9c43969e6f0df11ffe46db8d32
   md5: 4957e887b8ff6e7c1108e217b879ebc3
@@ -19598,6 +22391,28 @@ packages:
   run_exports: {}
   size: 1041066
   timestamp: 1785770469568
+- conda: https://conda.anaconda.org/conda-forge/win-64/libharfbuzz-14.3.1-h03b5201_0.conda
+  sha256: 79fa7b957cb1fa539b5be09a67872360e507a3f25501a0ceb26cda2b5091686e
+  md5: 72c117cd3215779e10bf16266db1d70e
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.15,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libglib >=2.88.3,<3.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 1042074
+  timestamp: 1786971066342
 - conda: https://conda.anaconda.org/conda-forge/win-64/libharfbuzz-devel-14.3.0-h03b5201_0.conda
   sha256: 54fea2e201eeb6940ff050ff4847c1021b69ad984881369470f1b2f0446c6340
   md5: caa9cfa4e495ec225e5ccde3cab32a88
@@ -19657,6 +22472,20 @@ packages:
     - libiconv >=1.18,<2.0a0
   size: 696926
   timestamp: 1754909290005
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_3.conda
+  sha256: 35e04e3ddac7720fc7c550a1c9f998604299d6a7bd1f3ec9b2825d825061daa2
+  md5: a8a2abdf0f901bc4779d9b7be0845921
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-only
+  purls: []
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
+  size: 694899
+  timestamp: 1787033851701
 - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
   sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
   md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
@@ -19832,6 +22661,22 @@ packages:
     - libpsl >=0.23.1,<0.24.0a0
   size: 73424
   timestamp: 1786443553911
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpsl-0.23.1-h9b16d47_1.conda
+  sha256: e53fe3b09f82b59b644264133d6d148ac31bb5451b7583cff55690bf038f2f62
+  md5: 39cdf8c4f59e4d253cfa8091c8b3d7de
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libpsl >=0.23.1,<0.24.0a0
+  size: 73511
+  timestamp: 1786970749988
 - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.11.05-h45f70d9_2.conda
   sha256: 255d32d01d72d7d89ab5c60c20b124216e0731428af350e40ed0e001d249bcb5
   md5: 52d096d535c65d26ffb4b84a4bba2aa1
@@ -19865,6 +22710,20 @@ packages:
     - libsodium >=1.0.22,<1.0.23.0a0
   size: 280234
   timestamp: 1779164124739
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.22-h6a83c73_2.conda
+  sha256: 7dc8d243cc8bcd12d1666640664288822eda5d30411a0b22ff05090bbac4c32b
+  md5: 2a001157df8205a7785ea69dd3270a8f
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: ISC
+  purls: []
+  run_exports:
+    weak:
+    - libsodium >=1.0.22,<1.0.23.0a0
+  size: 280204
+  timestamp: 1787225747847
 - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_0.conda
   sha256: 62e1c45ec71ab2e5deeeb0e47e7df6a609991e91d46348f16df50c68fee145c8
   md5: ca0d59f40a02a15e9b5d0ff8db0f85e3
@@ -19879,6 +22738,20 @@ packages:
     - libsqlite >=3.53.4,<4.0a0
   size: 1313790
   timestamp: 1785016158097
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_1.conda
+  sha256: 0a45d7c0f20146fff787a106f8fa187872e309c70975ff8f0936e188914c26ad
+  md5: a72d495965b144bb7da033642d389047
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 1314919
+  timestamp: 1787051140039
 - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h734d217_1.conda
   sha256: 1097b08429b4f53f5751a32c6d99a083d227ca7f7812c0b239eea124cec073a0
   md5: a21dd9ca39e74910bb96989feb916420
@@ -20060,6 +22933,24 @@ packages:
     - libxcb >=1.17.0,<2.0a0
   size: 1208687
   timestamp: 1727279378819
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.17.0-h874e120_1.conda
+  sha256: a99f266ade1140c3106cca0f71ae2b5627ff77e1e791db3837129d28d596800e
+  md5: 98046512ad7f2c44e48ff77bce854052
+  depends:
+  - libgcc >=13
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - pthread-stubs
+  - ucrt >=10.0.20348.0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdmcp >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
+  size: 1218652
+  timestamp: 1787077697863
 - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.3-h3cfd58e_0.conda
   sha256: 3b61ee3caba702d2ff432fa3920835db963026e5c99c4e6fdca0c6114f59e7ce
   md5: 9e8dd0d90ed830107b2c36801035b7db
@@ -20171,6 +23062,25 @@ packages:
   run_exports: {}
   size: 1208194
   timestamp: 1779194944505
+- conda: https://conda.anaconda.org/conda-forge/win-64/lxml-6.1.2-py310h095aac5_0.conda
+  sha256: 8903c88e373416a05143953a254027e72212fc15415406269c1652d239ddd5fe
+  md5: 02724d515697a81ff35caad2334d3451
+  depends:
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libxslt >=1.1.43,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause and MIT-CMU
+  purls:
+  - pkg:pypi/lxml?source=hash-mapping
+  run_exports: {}
+  size: 1215757
+  timestamp: 1787133274844
 - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.10.0-h6a83c73_2.conda
   sha256: 6824e36be0f95ae516dc36dddd18f69cbad0e4e07906fcb10a5f26a8dc471903
   md5: 3e0691cb20fcaf922df78ccea08b771a
@@ -20690,6 +23600,29 @@ packages:
   run_exports: {}
   size: 11461665
   timestamp: 1778933917882
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.2-py310h059d4f2_0.conda
+  sha256: 28c7b676f46e0653a851f85600362eae0c4db61f276e0f96b6552c1e3303d5e0
+  md5: 789352b89b81eff6bd731e8e218312da
+  depends:
+  - python
+  - qt6-main 6.11.2.*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - qt6-main >=6.11.2,<7.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libclang13 >=22.1.8
+  - libvulkan-loader >=1.4.357.0,<2.0a0
+  - python_abi 3.10.* *_cp310
+  - libxslt >=1.1.43,<2.0a0
+  license: LGPL-3.0-only
+  purls:
+  - pkg:pypi/pyside6?source=hash-mapping
+  - pkg:pypi/shiboken6?source=hash-mapping
+  run_exports: {}
+  size: 11436029
+  timestamp: 1787219451707
 - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.20-hc20f281_1_cpython.conda
   build_number: 1
   sha256: 71e2cdc0f87a0a2c5db7beb82469559bba1ce88a4fafe4e2d169172c2db45d1f
@@ -20909,6 +23842,43 @@ packages:
     - qt6-main >=6.11.1,<7.0a0
   size: 89576886
   timestamp: 1780400596481
+- conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.11.2-pl5321hfcac499_0.conda
+  sha256: 042c94a5a7a89b0b28a24f6ae6a2d3d609751edab78454057973ec5cc3e77d7d
+  md5: d98a163070d05c6ed4421432ee1bafb8
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libvulkan-loader >=1.4.357.0,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libharfbuzz >=14.3.1
+  - libzlib >=1.3.2,<2.0a0
+  - double-conversion >=3.4.0,<3.5.0a0
+  - libglib >=2.88.3,<3.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libtiff >=4.7.2,<4.8.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  constrains:
+  - qt ==6.11.2
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  run_exports:
+    weak:
+    - qt6-main >=6.11.2,<7.0a0
+  size: 89682645
+  timestamp: 1787049046883
 - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2025.11.05-haef9524_2.conda
   sha256: eb11c0e948c2576378a8e7f22768a967044d54bfbdea9ef358d31074b91c21f0
   md5: 5d51319ef836277672d665c2fc04bab0
@@ -21060,6 +24030,21 @@ packages:
     - libsqlite >=3.53.4,<4.0a0
   size: 426903
   timestamp: 1785016164714
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.53.4-hdb435a2_1.conda
+  sha256: 7616fec2d6ded67e111a47d4842738d0b3730c0acf3eaebe928cf6d3e15a6822
+  md5: df9d7c5d34602e0f2655a524d31fce87
+  depends:
+  - libsqlite 3.53.4 hf5d6505_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 426888
+  timestamp: 1787051146089
 - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
   sha256: 8a4053839b8e997a5965e2dff7d6cf3c77be62d82c0e48c8a04a5ed2d2e73035
   md5: 8ee01a693aecff5432069eaaf1183c45
@@ -21614,6 +24599,24 @@ packages:
   purls: []
   size: 7247
   timestamp: 1713892232423
+- pypi: https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl
+  name: aiosqlite
+  version: 0.22.1
+  sha256: 21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb
+  requires_dist:
+  - attribution==1.8.0 ; extra == 'dev'
+  - black==25.11.0 ; extra == 'dev'
+  - build>=1.2 ; extra == 'dev'
+  - coverage[toml]==7.10.7 ; extra == 'dev'
+  - flake8==7.3.0 ; extra == 'dev'
+  - flake8-bugbear==24.12.12 ; extra == 'dev'
+  - flit==3.12.0 ; extra == 'dev'
+  - mypy==1.19.0 ; extra == 'dev'
+  - ufmt==2.8.0 ; extra == 'dev'
+  - usort==1.0.8.post1 ; extra == 'dev'
+  - sphinx==8.1.3 ; extra == 'docs'
+  - sphinx-mdinclude==0.6.2 ; extra == 'docs'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl
   name: pydantic-core
   version: 2.46.4
@@ -21645,12 +24648,49 @@ packages:
   - pytest-asyncio>=0.26.0 ; extra == 'tests'
   - pytest-benchmark ; extra == 'tests'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/02/c8/79eee650c62d2c186598489814468e389b5def0ebe755399ff645b35b1b2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: watchfiles
+  version: 1.2.0
+  sha256: b62f042afde2dde21ec1d2c1a74361e804673df86f51e418a999c9acfe671b07
+  requires_dist:
+  - anyio>=3.0.0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl
+  name: cryptography
+  version: 50.0.0
+  sha256: ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07
+  requires_dist:
+  - cffi>=2.0.0 ; platform_python_implementation != 'PyPy'
+  - typing-extensions>=4.13.2 ; python_full_version < '3.11'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  requires_python: '!=3.9.0,>=3.9,!=3.9.1'
+- pypi: https://files.pythonhosted.org/packages/08/07/facef6abd81378e6153b757dc1848621675d971fbc88ebb5d182ebc1c37f/casbin-1.43.0-py3-none-any.whl
+  name: casbin
+  version: 1.43.0
+  sha256: 63a3d1228870250e859ccd94133fe478821093f71dd37f05e0baa0c6fea26623
+  requires_dist:
+  - simpleeval>=0.9.11
+  requires_python: '>=3.3'
 - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
   name: python-dotenv
   version: 1.2.2
   sha256: 1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a
   requires_dist:
   - click>=5.0 ; extra == 'cli'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
+  name: python-dotenv
+  version: 1.2.3
+  sha256: 904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9
+  requires_dist:
+  - click>=5.0 ; extra == 'cli'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/0d/5a/2bf22ecb24916983bf1cc0095e7dea2741d14d6553b0d6a2ac8bc96eca93/watchfiles-1.2.0-cp310-cp310-macosx_10_12_x86_64.whl
+  name: watchfiles
+  version: 1.2.0
+  sha256: bb68bf4df85abebe5efddc53cf2075520f243a59868d9b3973278b23e76962a9
+  requires_dist:
+  - anyio>=3.0.0
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/0d/e3/dbbf4b102f4e6aaf49ad3749a6d778f309473a2950c5ce3bb20b94f2ba84/bottleneck-1.6.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
   name: bottleneck
@@ -21661,6 +24701,42 @@ packages:
   - numpydoc ; extra == 'doc'
   - sphinx ; extra == 'doc'
   - gitpython ; extra == 'doc'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/0e/f8/17bda581c517678260e6541b600eeb67745f53596dc077174141ba2f6702/setproctitle-1.3.7-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: setproctitle
+  version: 1.3.7
+  sha256: 00afa6fc507967d8c9d592a887cdc6c1f5742ceac6a4354d111ca0214847732c
+  requires_dist:
+  - pytest ; extra == 'test'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl
+  name: simpleeval
+  version: 1.0.7
+  sha256: 97ac271bfd8f2af9e7b9a36ceea67617f26fa873f9d5ae1922f64d4c1442534b
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/10/74/c6f769aad8af584096d7e7d7d56ff081a2c9ee7a8a93d6ddea92ad26808a/seisbench-0.12.5.tar.gz
+  name: seisbench
+  version: 0.12.5
+  sha256: 02d44de38b7bb78836efa60d9db00e01cce87b13e714b2ef7355a01da4c1c99b
+  requires_dist:
+  - numpy>=1.21.6
+  - pandas>=1.1
+  - h5py>=3.1
+  - obspy>=1.3.1
+  - tqdm>=4.52
+  - torch>=1.10.0
+  - scipy>=1.9
+  - nest-asyncio>=1.5.3
+  - bottleneck>=1.3
+  - typing-extensions>=4.0
+  - xdas>=0.2.8 ; extra == 'das'
+  - pyarrow ; extra == 'das'
+  - torchvision ; extra == 'das'
+  - ruff ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - pytest ; extra == 'tests'
+  - pytest-asyncio>=0.26.0 ; extra == 'tests'
+  - pytest-benchmark ; extra == 'tests'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/14/d8/6d641573e210768816023a64966d66463f2ce9fc9945fa03290c8a18f87c/bottleneck-1.6.0.tar.gz
   name: bottleneck
@@ -21692,6 +24768,11 @@ packages:
   - pandas ; extra == 'tutorials'
   - tabulate ; extra == 'tutorials'
   requires_python: '>=3.10,<3.15'
+- pypi: https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl
+  name: protobuf
+  version: 6.33.6
+  sha256: e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/1d/f0/1ff90a1d1dd02de23feafdf9dffaecef3958348be5c192df56670ccb4f86/stamina-26.1.0-py3-none-any.whl
   name: stamina
   version: 26.1.0
@@ -21699,6 +24780,26 @@ packages:
   requires_dist:
   - tenacity
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl
+  name: alembic
+  version: 1.19.1
+  sha256: b39018cb3d9413a19cbd54cf3c02ad33998641f0538eb77413a488a21c3e14be
+  requires_dist:
+  - sqlalchemy>=1.4.23
+  - mako
+  - typing-extensions>=4.12
+  - tomli ; python_full_version < '3.11'
+  - tzdata ; extra == 'tz'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/20/b4/9fbb4b0af4e36d96a61d026dd37acab3cf521a70290a09640b215da5ab7c/asyncpg-0.31.0-cp310-cp310-win_amd64.whl
+  name: asyncpg
+  version: 0.31.0
+  sha256: 9ea33213ac044171f4cac23740bed9a3805abae10e7025314cfbd725ec670540
+  requires_dist:
+  - async-timeout>=4.0.3 ; python_full_version < '3.11'
+  - gssapi ; sys_platform != 'win32' and extra == 'gssauth'
+  - sspilib ; sys_platform == 'win32' and extra == 'gssauth'
+  requires_python: '>=3.9.0'
 - pypi: https://files.pythonhosted.org/packages/22/fa/b4e71bb8cb82ad7d21bb4e8c476f2d573ba68b20368aac36ef06e4a196b4/pymongo-4.17.0-cp310-cp310-win_amd64.whl
   name: pymongo
   version: 4.17.0
@@ -21728,6 +24829,14 @@ packages:
   - pytest>=8.2 ; extra == 'test'
   - backports-zstd>=1.0.0 ; python_full_version < '3.14' and extra == 'zstd'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/23/49/0c823a7627ff2e69a61e4a53c4edf215272892fc2c47c6431f033d46f4cc/grpcio-1.83.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: grpcio
+  version: 1.83.0
+  sha256: 4fcaa7c45c45b4a89e2867d1f1785d9481a788399d915e341ed2eb49aeef9dd4
+  requires_dist:
+  - typing-extensions~=4.12
+  - grpcio-tools>=1.83.0 ; extra == 'protobuf'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/28/d5/0a944773749b8659556a957f027332f939cb6913fb88267d8a5fbd026180/pyocto-0.1.4-cp310-cp310-win_amd64.whl
   name: pyocto
   version: 0.1.4
@@ -21745,6 +24854,13 @@ packages:
   version: 13.0.96
   sha256: 7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl
+  name: wheel
+  version: 0.48.0
+  sha256: 3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab
+  requires_dist:
+  - packaging>=24.0
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/2e/c9/0bb9d097b03cbaf96bb75b15e867347b8e41bfcdfe0539452d17d9e63993/torch-2.13.0-cp310-cp310-win_amd64.whl
   name: torch
   version: 2.13.0
@@ -21859,6 +24975,17 @@ packages:
   - opt-einsum>=3.3 ; extra == 'opt-einsum'
   - optree>=0.9.1 ; extra == 'optree'
   requires_python: '>=3.8.0'
+- pypi: https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl
+  name: passlib
+  version: 1.7.4
+  sha256: aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1
+  requires_dist:
+  - argon2-cffi>=18.2.0 ; extra == 'argon2'
+  - bcrypt>=3.1.0 ; extra == 'bcrypt'
+  - sphinx>=1.6 ; extra == 'build-docs'
+  - sphinxcontrib-fulltoc>=1.2.0 ; extra == 'build-docs'
+  - cloud-sptheme>=1.10.1 ; extra == 'build-docs'
+  - cryptography ; extra == 'totp'
 - pypi: https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl
   name: nvidia-cublas
   version: 13.1.1.3
@@ -21871,11 +24998,49 @@ packages:
   version: 3.4.5
   sha256: 290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl
+  name: annotated-doc
+  version: 0.0.5
+  sha256: 117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+  name: pynacl
+  version: 1.6.2
+  sha256: 8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c
+  requires_dist:
+  - cffi>=1.4.1 ; python_full_version < '3.9' and platform_python_implementation != 'PyPy'
+  - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
+  - pytest>=7.4.0 ; extra == 'tests'
+  - pytest-cov>=2.10.1 ; extra == 'tests'
+  - pytest-xdist>=3.5.0 ; extra == 'tests'
+  - hypothesis>=3.27.0 ; extra == 'tests'
+  - sphinx<7 ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: nvidia-cufile
   version: 1.15.1.6
   sha256: 08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/40/b9/be66eb0decd730d89b9c94f930e4b8d87787b05724bb84af98bfd825f72c/httptools-0.8.0-cp310-cp310-macosx_10_9_universal2.whl
+  name: httptools
+  version: 0.8.0
+  sha256: bf3b6f807c8541503cecfbb8a8dffb385640d0d96102f3d112aa8740f9b7c826
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl
+  name: pynacl
+  version: 1.6.2
+  sha256: 62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0
+  requires_dist:
+  - cffi>=1.4.1 ; python_full_version < '3.9' and platform_python_implementation != 'PyPy'
+  - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
+  - pytest>=7.4.0 ; extra == 'tests'
+  - pytest-cov>=2.10.1 ; extra == 'tests'
+  - pytest-xdist>=3.5.0 ; extra == 'tests'
+  - hypothesis>=3.27.0 ; extra == 'tests'
+  - sphinx<7 ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
   name: mpmath
   version: 1.3.0
@@ -21889,6 +25054,39 @@ packages:
   - sphinx ; extra == 'docs'
   - gmpy2>=2.1.0a4 ; platform_python_implementation != 'PyPy' and extra == 'gmpy'
   - pytest>=4.6 ; extra == 'tests'
+- pypi: https://files.pythonhosted.org/packages/46/81/d8c22cd7e5e1c6a7d48e41a1d1d46c92f17dae70a54d9814f746e6027dec/bcrypt-4.0.1-cp36-abi3-win_amd64.whl
+  name: bcrypt
+  version: 4.0.1
+  sha256: 8a68f4341daf7522fe8d73874de8906f3a339048ba406be6ddc1b3ccb16fc0d9
+  requires_dist:
+  - pytest>=3.2.1,!=3.3.0 ; extra == 'tests'
+  - mypy ; extra == 'typecheck'
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl
+  name: cryptography
+  version: 50.0.0
+  sha256: 105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025
+  requires_dist:
+  - cffi>=2.0.0 ; platform_python_implementation != 'PyPy'
+  - typing-extensions>=4.13.2 ; python_full_version < '3.11'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  requires_python: '!=3.9.0,>=3.9,!=3.9.1'
+- pypi: https://files.pythonhosted.org/packages/47/92/2091275a9025f9b9ef9bf72ae386786a9b03af9515f5e2f5befb012ec91f/pendulum-3.2.0-cp310-cp310-macosx_11_0_arm64.whl
+  name: pendulum
+  version: 3.2.0
+  sha256: 625209bb7133d990905e8935e1c04f0a82315ae777b67910969b16f665d62c0b
+  requires_dist:
+  - python-dateutil>=2.6
+  - tzdata>=2020.1
+  - time-machine>=2.6.0,<3.0.0 ; implementation_name != 'pypy' and extra == 'test'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/4c/16/fca52784f979821e2205ff514322d0e83452536acc4807a79ddb2085bbb2/types_paramiko-5.0.0.20260724-py3-none-any.whl
+  name: types-paramiko
+  version: 5.0.0.20260724
+  sha256: 40c7083803a5a28ab7a8d2fe4cd9b7746d0a03538598582ce68f60967a2ad272
+  requires_dist:
+  - cryptography>=37.0.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/4f/c9/7352e0c20fe772541556e4d283c05e07ec48f8b0d2737ad930ac4a1b6655/pymongo-4.17.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: pymongo
   version: 4.17.0
@@ -21941,12 +25139,62 @@ packages:
   - opt-einsum>=3.3 ; extra == 'opt-einsum'
   - pyyaml ; extra == 'pyyaml'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/54/82/1013a5fe7ddae8e102bc3b4b39db81d8d28fd02100a324ce6ede8cd832b1/websockets-16.1.1-cp310-cp310-win_amd64.whl
+  name: websockets
+  version: 16.1.1
+  sha256: d57685547e0060cc6fd90ee6a28405d6bd395e525545f13c8d7cd99c78afd79f
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/55/70/dea1f6a0e76607841a60fb51af150e70124864673f61704abb62b90cdcc7/watchfiles-1.2.0-cp310-cp310-macosx_11_0_arm64.whl
+  name: watchfiles
+  version: 1.2.0
+  sha256: c16cb06dd17d43b9d185094268459eac92c9538356f050e55b54e82cf700e1d4
+  requires_dist:
+  - anyio>=3.0.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl
   name: pydantic-core
   version: 2.46.4
   sha256: da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5
   requires_dist:
   - typing-extensions>=4.14.1
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl
+  name: cryptography
+  version: 50.0.0
+  sha256: d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba
+  requires_dist:
+  - cffi>=2.0.0 ; platform_python_implementation != 'PyPy'
+  - typing-extensions>=4.13.2 ; python_full_version < '3.11'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  requires_python: '!=3.9.0,>=3.9,!=3.9.1'
+- pypi: https://files.pythonhosted.org/packages/57/dd/babfb85ad163c1eadb06bd813571532cdee4b4a356817cb481da8165136c/seisbench-0.12.5-cp310-cp310-win_amd64.whl
+  name: seisbench
+  version: 0.12.5
+  sha256: dcaa95ab6abb9e60e39be92023f0ae482c44b4cf6bec05d81fa70807b9b6d593
+  requires_dist:
+  - numpy>=1.21.6
+  - pandas>=1.1
+  - h5py>=3.1
+  - obspy>=1.3.1
+  - tqdm>=4.52
+  - torch>=1.10.0
+  - scipy>=1.9
+  - nest-asyncio>=1.5.3
+  - bottleneck>=1.3
+  - typing-extensions>=4.0
+  - xdas>=0.2.8 ; extra == 'das'
+  - pyarrow ; extra == 'das'
+  - torchvision ; extra == 'das'
+  - ruff ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - pytest ; extra == 'tests'
+  - pytest-asyncio>=0.26.0 ; extra == 'tests'
+  - pytest-benchmark ; extra == 'tests'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl
+  name: invoke
+  version: 3.0.3
+  sha256: f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl
   name: torch
@@ -21981,6 +25229,11 @@ packages:
   - opt-einsum>=3.3 ; extra == 'opt-einsum'
   - pyyaml ; extra == 'pyyaml'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl
+  name: protobuf
+  version: 6.33.6
+  sha256: 9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/5d/02/d2b8ec2172577329daec50b0e547ac68955e04983ae42367fe3ae8388229/aioboto3-7.0.0-py2.py3-none-any.whl
   name: aioboto3
   version: 7.0.0
@@ -21998,6 +25251,19 @@ packages:
   - nvidia-nvjitlink
   - nvidia-cusparse
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/64/fe/da28a5916128d541da0993328dc5cf4b43dfbf6655f2c7a2abe26ca2dc88/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_x86_64.whl
+  name: bcrypt
+  version: 4.0.1
+  sha256: ca3204d00d3cb2dfed07f2d74a25f12fc12f73e606fcaa6975d1f7ae69cacbb2
+  requires_dist:
+  - pytest>=3.2.1,!=3.3.0 ; extra == 'tests'
+  - mypy ; extra == 'typecheck'
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/65/9b/4df366d89f28c527dc39d0b6c98a5ca74e30d37ac097b73f3352147568ae/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: psycopg2-binary
+  version: 2.9.12
+  sha256: c5ee5213445dd45312459029b8c4c0a695461eb517b753d2582315bd07995f5e
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/66/35/d88fd6718832133c885004c61ceeeb24dbd6397ef877dbed6b3a64d6a286/h5py-3.16.0-cp310-cp310-win_amd64.whl
   name: h5py
   version: 3.16.0
@@ -22040,6 +25306,13 @@ packages:
   - pytest-asyncio ; extra == 'dev'
   - ruff ; extra == 'dev'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/6d/68/a5e67b6b68e94f4c1511d61c46c55eba0737583620b6febf194c7b9cc23f/watchfiles-1.2.0-cp310-cp310-win_amd64.whl
+  name: watchfiles
+  version: 1.2.0
+  sha256: 03b14855c6f35539e2d95c442ae9530a75762f1e26567152b9ed05f96534a74d
+  requires_dist:
+  - anyio>=3.0.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl
   name: nvidia-cudnn-cu13
   version: 9.20.0.48
@@ -22047,6 +25320,11 @@ packages:
   requires_dist:
   - nvidia-cublas
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/73/99/21af7a5498637ea4dc91a17c281a53bc1d632fbafe00f6689fbfb32a9fed/psycopg2_binary-2.9.12-cp310-cp310-win_amd64.whl
+  name: psycopg2-binary
+  version: 2.9.12
+  sha256: ab29414b25dcb698bf26bf213e3348abdcd07bbd5de032a5bec15bd75b298b03
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/74/f9/557ce3aad0fe8471fb5279bab0fc56ea473858a022c4ce8a0b8f303d64e9/h5py-3.16.0-cp310-cp310-macosx_11_0_arm64.whl
   name: h5py
   version: 3.16.0
@@ -22059,6 +25337,24 @@ packages:
   version: 3.12.0
   sha256: e9683ee9ea0659da64f36574ef675b8a86330c34c19ea75db1fb93c3ff99e0ef
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl
+  name: protobuf
+  version: 6.33.6
+  sha256: 0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/78/80/49bacf9e51617d8309f6f0123e29edc793f6f5f6700c7d1f1b20782fbb37/psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl
+  name: psycopg2-binary
+  version: 2.9.12
+  sha256: 9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl
+  name: bcrypt
+  version: 4.0.1
+  sha256: b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f
+  requires_dist:
+  - pytest>=3.2.1,!=3.3.0 ; extra == 'tests'
+  - mypy ; extra == 'typecheck'
+  requires_python: '>=3.6'
 - pypi: https://files.pythonhosted.org/packages/7e/65/4ef337df42cc19353880256d6c9307904669d790c6ca6904b38a9dde3eac/seisbench-0.12.3-cp310-cp310-win_amd64.whl
   name: seisbench
   version: 0.12.3
@@ -22083,6 +25379,33 @@ packages:
   - pytest-asyncio>=0.26.0 ; extra == 'tests'
   - pytest-benchmark ; extra == 'tests'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl
+  name: click
+  version: 8.1.8
+  sha256: 63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2
+  requires_dist:
+  - colorama ; sys_platform == 'win32'
+  - importlib-metadata ; python_full_version < '3.8'
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+  name: rich
+  version: 15.0.0
+  sha256: 33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb
+  requires_dist:
+  - ipywidgets>=7.5.1,<9 ; extra == 'jupyter'
+  - markdown-it-py>=2.2.0
+  - pygments>=2.13.0,<3.0.0
+  requires_python: '>=3.9.0'
+- pypi: https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl
+  name: paramiko
+  version: 5.0.0
+  sha256: b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c
+  requires_dist:
+  - bcrypt>=3.2
+  - cryptography>=3.3
+  - invoke>=2.0
+  - pynacl>=1.5
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/88/cf/5a70cee503ff9a2fea20607607f14d189f4d975960ac0945ec306ee7b695/pymongo-4.17.0-cp310-cp310-macosx_11_0_arm64.whl
   name: pymongo
   version: 4.17.0
@@ -22136,11 +25459,46 @@ packages:
   - pytest-asyncio>=0.26.0 ; extra == 'tests'
   - pytest-benchmark ; extra == 'tests'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/90/72/2f14b2e167170b8bf1c8bb7f9b0d78000f470d41a2085a91f33e3917b6c9/websockets-16.1.1-cp310-cp310-macosx_11_0_arm64.whl
+  name: websockets
+  version: 16.1.1
+  sha256: 9246a0d063cfcbcc85f2359dd6876d681213f4790832272aa16641b4ed5d64d4
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl
+  name: docutils
+  version: '0.19'
+  sha256: 5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+  name: tabulate
+  version: 0.10.0
+  sha256: f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
+  requires_dist:
+  - wcwidth ; extra == 'widechars'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
   name: annotated-types
   version: 0.8.0
   sha256: f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/99/f5/70df723bf571f5e0b1b845e0a4ff1c966eeb84f667599fc251caa37d15a3/websockets-16.1.1-cp310-cp310-macosx_10_9_x86_64.whl
+  name: websockets
+  version: 16.1.1
+  sha256: 5bfd1ac19b1b9986a9c95a82d5e23a391ebb09e12c34d7be6094b86efcc35731
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl
+  name: pyasn1
+  version: 0.6.4
+  sha256: deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/9b/85/bfd277c82b52318725499855e7ea42368d49df3327dbc63ea16ba9973fc0/sqlalchemy_adapter-1.9.0-py3-none-any.whl
+  name: sqlalchemy-adapter
+  version: 1.9.0
+  sha256: 7c100e2f9c4ca82a2dad82b9b8e4a2f03f3aa2d0204732e138e41c46623da6f7
+  requires_dist:
+  - pycasbin>=2.0.0
+  - sqlalchemy>=1.2.18
+  requires_python: '>=3.3'
 - pypi: https://files.pythonhosted.org/packages/9c/38/144fb32c9efb196f651ddb30e7c48f6047a86972e5b350f3f10c9a5f6a16/bottleneck-1.6.0-cp310-cp310-macosx_11_0_arm64.whl
   name: bottleneck
   version: 1.6.0
@@ -22151,6 +25509,28 @@ packages:
   - sphinx ; extra == 'doc'
   - gitpython ; extra == 'doc'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/9d/ea/e4d3f64822fb29d54970909e1e2784daa17f75fe3c6c27544fe92e247aad/ijson-3.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: ijson
+  version: 3.5.1
+  sha256: 70542d4542f079c394e525559188d69e3ccfbfd9bab899acd0bf1dbc7323ddd5
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/9d/f7/b4d41eaae2869d31356bc4bbf546f44fae83ff298af0a043ca0625b06773/httptools-0.8.0-cp310-cp310-macosx_11_0_arm64.whl
+  name: httptools
+  version: 0.8.0
+  sha256: da684f2e1aa2ee9bdcb083f3f3a68c5956750b375bc5df864d3a5f0c42a40b77
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
+  name: gitdb
+  version: 4.0.12
+  sha256: 67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
+  requires_dist:
+  - smmap>=3.0.1,<6
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/a0/ad/8d9e1f076560efcc6727b06f3276f30bb811961332d83567de70c179e0e8/ijson-3.5.1-cp310-cp310-macosx_10_9_x86_64.whl
+  name: ijson
+  version: 3.5.1
+  sha256: 9708c0a3d1f86056049de631933aef8ec57f2008d4cb55ce241790c7ed557428
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
   name: nest-asyncio
   version: 1.6.0
@@ -22165,6 +25545,24 @@ packages:
   - pytest>=7.1.0 ; extra == 'dev'
   - hypothesis>=6.70.0 ; extra == 'dev'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+  name: pyjwt
+  version: 2.13.0
+  sha256: 66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
+  requires_dist:
+  - typing-extensions>=4.0 ; python_full_version < '3.11'
+  - cryptography>=3.4.0 ; extra == 'crypto'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
+  name: mako
+  version: 1.4.1
+  sha256: a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617
+  requires_dist:
+  - markupsafe>=2.0
+  - pytest ; extra == 'testing'
+  - babel ; extra == 'babel'
+  - lingua>=4.16 ; extra == 'lingua'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl
   name: nvidia-curand
   version: 10.4.0.35
@@ -22193,6 +25591,11 @@ packages:
   requires_dist:
   - nvidia-nvjitlink
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/ab/e7/8f001e823846c270e0e9c3526ea99dc3b1ba51b9501e060d8337830d6c76/ijson-3.5.1-cp310-cp310-macosx_11_0_arm64.whl
+  name: ijson
+  version: 3.5.1
+  sha256: 904e8cf9ca69f5de5b6bb405a4a075ce3da3413ad50c11f6813f1201e14a8e45
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/ab/fb/75f04721aa515fd293346f09da53cf24601f356b6b1a52e50cee10af67bc/seisbench-0.12.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
   name: seisbench
   version: 0.12.3
@@ -22216,6 +25619,76 @@ packages:
   - pytest ; extra == 'tests'
   - pytest-asyncio>=0.26.0 ; extra == 'tests'
   - pytest-benchmark ; extra == 'tests'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ae/72/cecb1710c36c6fe61e545050607c2050a2af0b991cf1a3d83981dfd895e8/pendulum-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: pendulum
+  version: 3.2.0
+  sha256: 04310463879a8d84534756ef9820d433e88b879203b6e10a5b416899dc05e7f1
+  requires_dist:
+  - python-dateutil>=2.6
+  - tzdata>=2020.1
+  - time-machine>=2.6.0,<3.0.0 ; implementation_name != 'pypy' and extra == 'test'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+  name: mdurl
+  version: 0.1.2
+  sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+  name: markdown-it-py
+  version: 4.2.0
+  sha256: 9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
+  requires_dist:
+  - mdurl~=0.1
+  - psutil ; extra == 'benchmarking'
+  - pytest ; extra == 'benchmarking'
+  - pytest-benchmark ; extra == 'benchmarking'
+  - commonmark~=0.9 ; extra == 'compare'
+  - markdown~=3.4 ; extra == 'compare'
+  - mistletoe~=1.0 ; extra == 'compare'
+  - mistune~=3.0 ; extra == 'compare'
+  - panflute~=2.3 ; extra == 'compare'
+  - markdown-it-pyrs ; extra == 'compare'
+  - linkify-it-py>=1,<3 ; extra == 'linkify'
+  - mdit-py-plugins>=0.5.0 ; extra == 'plugins'
+  - gprof2dot ; extra == 'profiling'
+  - mdit-py-plugins>=0.5.0 ; extra == 'rtd'
+  - myst-parser ; extra == 'rtd'
+  - pyyaml ; extra == 'rtd'
+  - sphinx ; extra == 'rtd'
+  - sphinx-copybutton ; extra == 'rtd'
+  - sphinx-design ; extra == 'rtd'
+  - sphinx-book-theme~=1.0 ; extra == 'rtd'
+  - jupyter-sphinx ; extra == 'rtd'
+  - ipykernel ; extra == 'rtd'
+  - coverage ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-regressions ; extra == 'testing'
+  - pytest-timeout ; extra == 'testing'
+  - requests ; extra == 'testing'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b3/f6/21657bb3beb5f8c57ce8be3b83f653dd7933c2fd00545ed1b092d464799a/uvloop-0.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: uvloop
+  version: 0.22.1
+  sha256: 481c990a7abe2c6f4fc3d98781cc9426ebd7f03a9aaa7eb03d3bfc68ac2a46bd
+  requires_dist:
+  - aiohttp>=3.10.5 ; extra == 'test'
+  - flake8~=6.1 ; extra == 'test'
+  - psutil ; extra == 'test'
+  - pycodestyle~=2.11.0 ; extra == 'test'
+  - pyopenssl~=25.3.0 ; extra == 'test'
+  - mypy>=0.800 ; extra == 'test'
+  - setuptools>=60 ; extra == 'dev'
+  - cython~=3.0 ; extra == 'dev'
+  - sphinx~=4.1.2 ; extra == 'docs'
+  - sphinxcontrib-asyncio~=0.3.0 ; extra == 'docs'
+  - sphinx-rtd-theme~=0.5.2 ; extra == 'docs'
+  requires_python: '>=3.8.1'
+- pypi: https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl
+  name: bracex
+  version: 3.0.1
+  sha256: 6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
   name: networkx
@@ -22310,6 +25783,23 @@ packages:
   - trio>=0.30 ; extra == 'trio'
   - wmi>=1.5.1 ; sys_platform == 'win32' and extra == 'wmi'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ba/ae/6f6f9af7f590b319c94532b9567409ba11f4fa71af1148cab1bf48a07048/uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl
+  name: uvloop
+  version: 0.22.1
+  sha256: 7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792
+  requires_dist:
+  - aiohttp>=3.10.5 ; extra == 'test'
+  - flake8~=6.1 ; extra == 'test'
+  - psutil ; extra == 'test'
+  - pycodestyle~=2.11.0 ; extra == 'test'
+  - pyopenssl~=25.3.0 ; extra == 'test'
+  - mypy>=0.800 ; extra == 'test'
+  - setuptools>=60 ; extra == 'dev'
+  - cython~=3.0 ; extra == 'dev'
+  - sphinx~=4.1.2 ; extra == 'docs'
+  - sphinxcontrib-asyncio~=0.3.0 ; extra == 'docs'
+  - sphinx-rtd-theme~=0.5.2 ; extra == 'docs'
+  requires_python: '>=3.8.1'
 - pypi: https://files.pythonhosted.org/packages/bb/c6/0cd524132e0a558ce8ee0a32bd2308c18abd84a2c9374dc909146244534c/pyocto-0.1.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: pyocto
   version: 0.1.4
@@ -22322,11 +25812,35 @@ packages:
   - pyrocko>=2023.6.29 ; extra == 'test'
   - pyarrow>=12.0.1 ; extra == 'test'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/bb/e8/86b85bbc0ac7892232f1a99ab96a9aa71936984fa06adfc0afc83ca7789e/httptools-0.8.0-cp310-cp310-win_amd64.whl
+  name: httptools
+  version: 0.8.0
+  sha256: b205e5f5523fa039679da0dfe5a10132b2a4abeae6a86fdd1ddc035f7f836557
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
   name: aiofiles
   version: 25.1.0
   sha256: abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl
+  name: pynacl
+  version: 1.6.2
+  sha256: c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465
+  requires_dist:
+  - cffi>=1.4.1 ; python_full_version < '3.9' and platform_python_implementation != 'PyPy'
+  - cffi>=2.0.0 ; python_full_version >= '3.9' and platform_python_implementation != 'PyPy'
+  - pytest>=7.4.0 ; extra == 'tests'
+  - pytest-cov>=2.10.1 ; extra == 'tests'
+  - pytest-xdist>=3.5.0 ; extra == 'tests'
+  - hypothesis>=3.27.0 ; extra == 'tests'
+  - sphinx<7 ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
+  name: smmap
+  version: 5.0.3
+  sha256: c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl
   name: nvidia-nvtx
   version: 13.0.85
@@ -22337,6 +25851,29 @@ packages:
   version: 13.0.88
   sha256: ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/c3/d9/507c80bdac2e95e5a525644af94b03fa7f9a44596a84bd48a6e80f854f92/asyncpg-0.31.0-cp310-cp310-macosx_10_9_x86_64.whl
+  name: asyncpg
+  version: 0.31.0
+  sha256: 831712dd3cf117eec68575a9b50da711893fd63ebe277fc155ecae1c6c9f0f61
+  requires_dist:
+  - async-timeout>=4.0.3 ; python_full_version < '3.11'
+  - gssapi ; sys_platform != 'win32' and extra == 'gssauth'
+  - sspilib ; sys_platform == 'win32' and extra == 'gssauth'
+  requires_python: '>=3.9.0'
+- pypi: https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl
+  name: starlette
+  version: 1.6.0
+  sha256: a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c
+  requires_dist:
+  - anyio>=3.6.2,<5
+  - typing-extensions>=4.10.0 ; python_full_version < '3.13'
+  - httpx2>=2.0.0 ; extra == 'full'
+  - httpx>=0.27.0,<0.29.0 ; extra == 'full'
+  - itsdangerous ; extra == 'full'
+  - jinja2 ; extra == 'full'
+  - python-multipart>=0.0.18 ; extra == 'full'
+  - pyyaml ; extra == 'full'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/c9/77/28ebbf69772a4341d530831c7a006cdb06877ac23075cb53b0a227df4fe1/pymongo-4.17.0-cp310-cp310-macosx_10_9_x86_64.whl
   name: pymongo
   version: 4.17.0
@@ -22366,6 +25903,53 @@ packages:
   - pytest>=8.2 ; extra == 'test'
   - backports-zstd>=1.0.0 ; python_full_version < '3.14' and extra == 'zstd'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/ca/a4/934d8c97851bda5a034b0fd0512689173c8ca8cb3b87ebf8e5c1364d57f3/pendulum-3.2.0-cp310-cp310-macosx_10_12_x86_64.whl
+  name: pendulum
+  version: 3.2.0
+  sha256: 4a6bf778c6b42830b001c714dae5b9dad78da38e2e08203a4b0f5d53f8fa5e63
+  requires_dist:
+  - python-dateutil>=2.6
+  - tzdata>=2020.1
+  - time-machine>=2.6.0,<3.0.0 ; implementation_name != 'pypy' and extra == 'test'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl
+  name: fastapi
+  version: 0.141.1
+  sha256: bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3
+  requires_dist:
+  - starlette>=0.46.0
+  - pydantic>=2.9.0
+  - typing-extensions>=4.8.0
+  - typing-inspection>=0.4.2
+  - annotated-doc>=0.0.2
+  - fastapi-cli[standard]>=0.0.32 ; extra == 'standard'
+  - fastar>=0.9.0 ; extra == 'standard'
+  - httpx>=0.23.0,<1.0.0 ; extra == 'standard'
+  - jinja2>=3.1.5 ; extra == 'standard'
+  - python-multipart>=0.0.18 ; extra == 'standard'
+  - email-validator>=2.0.0 ; extra == 'standard'
+  - uvicorn[standard]>=0.12.0 ; extra == 'standard'
+  - pydantic-settings>=2.0.0 ; extra == 'standard'
+  - pydantic-extra-types>=2.0.0 ; extra == 'standard'
+  - fastapi-cli[standard-no-fastapi-cloud-cli]>=0.0.32 ; extra == 'standard-no-fastapi-cloud-cli'
+  - httpx>=0.23.0,<1.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - jinja2>=3.1.5 ; extra == 'standard-no-fastapi-cloud-cli'
+  - python-multipart>=0.0.18 ; extra == 'standard-no-fastapi-cloud-cli'
+  - email-validator>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - uvicorn[standard]>=0.12.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - pydantic-settings>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - pydantic-extra-types>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
+  - fastapi-cli[standard]>=0.0.32 ; extra == 'all'
+  - httpx>=0.23.0,<1.0.0 ; extra == 'all'
+  - jinja2>=3.1.5 ; extra == 'all'
+  - python-multipart>=0.0.18 ; extra == 'all'
+  - itsdangerous>=1.1.0 ; extra == 'all'
+  - pyyaml>=5.3.1 ; extra == 'all'
+  - email-validator>=2.0.0 ; extra == 'all'
+  - uvicorn[standard]>=0.12.0 ; extra == 'all'
+  - pydantic-settings>=2.0.0 ; extra == 'all'
+  - pydantic-extra-types>=2.0.0 ; extra == 'all'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/cb/92/a8851d936547efe30cc0ce5245feac01f3ec6171f7899bc3f775c72030b3/h5py-3.16.0-cp310-cp310-manylinux_2_28_x86_64.whl
   name: h5py
   version: 3.16.0
@@ -22373,16 +25957,497 @@ packages:
   requires_dist:
   - numpy>=1.21.2
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/cb/d9/a503213b79d362e7a5da595dd7fa38186a6d1adb3642466f1399045bafe2/skypilot-0.13.0-py3-none-any.whl
+  name: skypilot
+  version: 0.13.0
+  sha256: 30411fb3622140e61d386494dfaaeefaee737f76565a3838d72a31157571d96c
+  requires_dist:
+  - wheel>=0.46.3
+  - setuptools
+  - pip
+  - cachetools
+  - click>=7.0,<8.2.0
+  - colorama
+  - cryptography
+  - jinja2>=3.0
+  - jsonschema
+  - networkx
+  - pandas>=1.3.0
+  - pendulum
+  - prettytable>=2.0.0
+  - python-dotenv
+  - rich
+  - tabulate
+  - tqdm
+  - typing-extensions
+  - filelock>=3.15.0
+  - packaging
+  - psutil
+  - pulp
+  - pyyaml>3.13,!=5.4.*
+  - ijson
+  - orjson
+  - requests
+  - uvicorn[standard]>=0.33.0,<0.36.0
+  - fastapi
+  - pydantic!=2.0.*,>2,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3
+  - python-multipart
+  - aiofiles
+  - httpx
+  - setproctitle
+  - sqlalchemy>=2.0.16
+  - psycopg2-binary
+  - aiosqlite
+  - asyncpg
+  - greenlet
+  - casbin
+  - sqlalchemy-adapter
+  - prometheus-client>=0.8.0
+  - passlib
+  - bcrypt==4.0.1
+  - pyjwt
+  - gitpython
+  - paramiko
+  - types-paramiko
+  - alembic>=1.8.0
+  - aiohttp>=3.13.3
+  - anyio
+  - awscli>=1.27.10 ; extra == 'aws'
+  - botocore>=1.29.10 ; extra == 'aws'
+  - boto3>=1.26.1 ; extra == 'aws'
+  - colorama<0.4.7 ; extra == 'aws'
+  - casbin ; extra == 'aws'
+  - sqlalchemy-adapter ; extra == 'aws'
+  - passlib ; extra == 'aws'
+  - pyjwt ; extra == 'aws'
+  - aiohttp ; extra == 'aws'
+  - anyio ; extra == 'aws'
+  - grpcio>=1.63.0 ; extra == 'aws'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'aws'
+  - aiosqlite ; extra == 'aws'
+  - azure-cli>=2.65.0,<2.87.0 ; extra == 'azure'
+  - azure-core>=1.31.0 ; extra == 'azure'
+  - azure-identity>=1.19.0 ; extra == 'azure'
+  - azure-mgmt-network>=27.0.0 ; extra == 'azure'
+  - azure-mgmt-compute>=33.0.0 ; extra == 'azure'
+  - azure-storage-blob>=12.23.1 ; extra == 'azure'
+  - msgraph-sdk ; extra == 'azure'
+  - msrestazure ; extra == 'azure'
+  - casbin ; extra == 'azure'
+  - sqlalchemy-adapter ; extra == 'azure'
+  - passlib ; extra == 'azure'
+  - pyjwt ; extra == 'azure'
+  - aiohttp ; extra == 'azure'
+  - anyio ; extra == 'azure'
+  - grpcio>=1.63.0 ; extra == 'azure'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'azure'
+  - aiosqlite ; extra == 'azure'
+  - google-api-python-client>=2.69.0 ; extra == 'gcp'
+  - google-cloud-storage ; extra == 'gcp'
+  - pyopenssl>=23.2.0 ; extra == 'gcp'
+  - casbin ; extra == 'gcp'
+  - sqlalchemy-adapter ; extra == 'gcp'
+  - passlib ; extra == 'gcp'
+  - pyjwt ; extra == 'gcp'
+  - aiohttp ; extra == 'gcp'
+  - anyio ; extra == 'gcp'
+  - grpcio>=1.63.0 ; extra == 'gcp'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'gcp'
+  - aiosqlite ; extra == 'gcp'
+  - ibm-cloud-sdk-core ; extra == 'ibm'
+  - ibm-vpc ; extra == 'ibm'
+  - ibm-platform-services>=0.48.0 ; extra == 'ibm'
+  - ibm-cos-sdk ; extra == 'ibm'
+  - ray[default]>=2.6.1 ; extra == 'ibm'
+  - casbin ; extra == 'ibm'
+  - sqlalchemy-adapter ; extra == 'ibm'
+  - passlib ; extra == 'ibm'
+  - pyjwt ; extra == 'ibm'
+  - aiohttp ; extra == 'ibm'
+  - anyio ; extra == 'ibm'
+  - grpcio>=1.63.0 ; extra == 'ibm'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'ibm'
+  - aiosqlite ; extra == 'ibm'
+  - docker ; extra == 'docker'
+  - ray[default]>=2.6.1 ; extra == 'docker'
+  - casbin ; extra == 'docker'
+  - sqlalchemy-adapter ; extra == 'docker'
+  - passlib ; extra == 'docker'
+  - pyjwt ; extra == 'docker'
+  - aiohttp ; extra == 'docker'
+  - anyio ; extra == 'docker'
+  - grpcio>=1.63.0 ; extra == 'docker'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'docker'
+  - aiosqlite ; extra == 'docker'
+  - casbin ; extra == 'lambda'
+  - sqlalchemy-adapter ; extra == 'lambda'
+  - passlib ; extra == 'lambda'
+  - pyjwt ; extra == 'lambda'
+  - aiohttp ; extra == 'lambda'
+  - anyio ; extra == 'lambda'
+  - grpcio>=1.63.0 ; extra == 'lambda'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'lambda'
+  - aiosqlite ; extra == 'lambda'
+  - awscli>=1.27.10 ; extra == 'cloudflare'
+  - botocore>=1.29.10 ; extra == 'cloudflare'
+  - boto3>=1.26.1 ; extra == 'cloudflare'
+  - colorama<0.4.7 ; extra == 'cloudflare'
+  - casbin ; extra == 'cloudflare'
+  - sqlalchemy-adapter ; extra == 'cloudflare'
+  - passlib ; extra == 'cloudflare'
+  - pyjwt ; extra == 'cloudflare'
+  - aiohttp ; extra == 'cloudflare'
+  - anyio ; extra == 'cloudflare'
+  - grpcio>=1.63.0 ; extra == 'cloudflare'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'cloudflare'
+  - aiosqlite ; extra == 'cloudflare'
+  - awscli>=1.27.10 ; extra == 'coreweave'
+  - botocore>=1.29.10 ; extra == 'coreweave'
+  - boto3>=1.26.1 ; extra == 'coreweave'
+  - colorama<0.4.7 ; extra == 'coreweave'
+  - kubernetes>=20.0.0,!=32.0.0,<36.0.0 ; extra == 'coreweave'
+  - websockets ; extra == 'coreweave'
+  - python-dateutil ; extra == 'coreweave'
+  - casbin ; extra == 'coreweave'
+  - sqlalchemy-adapter ; extra == 'coreweave'
+  - passlib ; extra == 'coreweave'
+  - pyjwt ; extra == 'coreweave'
+  - aiohttp ; extra == 'coreweave'
+  - anyio ; extra == 'coreweave'
+  - grpcio>=1.63.0 ; extra == 'coreweave'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'coreweave'
+  - aiosqlite ; extra == 'coreweave'
+  - huggingface-hub>=1.5 ; python_full_version >= '3.10' and extra == 'huggingface'
+  - huggingface-hub>=1.5,<1.9 ; python_full_version < '3.10' and extra == 'huggingface'
+  - casbin ; extra == 'huggingface'
+  - sqlalchemy-adapter ; extra == 'huggingface'
+  - passlib ; extra == 'huggingface'
+  - pyjwt ; extra == 'huggingface'
+  - aiohttp ; extra == 'huggingface'
+  - anyio ; extra == 'huggingface'
+  - grpcio>=1.63.0 ; extra == 'huggingface'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'huggingface'
+  - aiosqlite ; extra == 'huggingface'
+  - ray[default]>=2.6.1 ; extra == 'scp'
+  - casbin ; extra == 'scp'
+  - sqlalchemy-adapter ; extra == 'scp'
+  - passlib ; extra == 'scp'
+  - pyjwt ; extra == 'scp'
+  - aiohttp ; extra == 'scp'
+  - anyio ; extra == 'scp'
+  - grpcio>=1.63.0 ; extra == 'scp'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'scp'
+  - aiosqlite ; extra == 'scp'
+  - oci ; extra == 'oci'
+  - casbin ; extra == 'oci'
+  - sqlalchemy-adapter ; extra == 'oci'
+  - passlib ; extra == 'oci'
+  - pyjwt ; extra == 'oci'
+  - aiohttp ; extra == 'oci'
+  - anyio ; extra == 'oci'
+  - grpcio>=1.63.0 ; extra == 'oci'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'oci'
+  - aiosqlite ; extra == 'oci'
+  - kubernetes>=20.0.0,!=32.0.0,<36.0.0 ; extra == 'kubernetes'
+  - websockets ; extra == 'kubernetes'
+  - python-dateutil ; extra == 'kubernetes'
+  - casbin ; extra == 'kubernetes'
+  - sqlalchemy-adapter ; extra == 'kubernetes'
+  - passlib ; extra == 'kubernetes'
+  - pyjwt ; extra == 'kubernetes'
+  - aiohttp ; extra == 'kubernetes'
+  - anyio ; extra == 'kubernetes'
+  - grpcio>=1.63.0 ; extra == 'kubernetes'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'kubernetes'
+  - aiosqlite ; extra == 'kubernetes'
+  - kubernetes>=20.0.0,!=32.0.0,<36.0.0 ; extra == 'ssh'
+  - websockets ; extra == 'ssh'
+  - python-dateutil ; extra == 'ssh'
+  - casbin ; extra == 'ssh'
+  - sqlalchemy-adapter ; extra == 'ssh'
+  - passlib ; extra == 'ssh'
+  - pyjwt ; extra == 'ssh'
+  - aiohttp ; extra == 'ssh'
+  - anyio ; extra == 'ssh'
+  - grpcio>=1.63.0 ; extra == 'ssh'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'ssh'
+  - aiosqlite ; extra == 'ssh'
+  - runpod>=1.6.1 ; extra == 'runpod'
+  - tomli ; extra == 'runpod'
+  - pycares<5 ; extra == 'runpod'
+  - casbin ; extra == 'runpod'
+  - sqlalchemy-adapter ; extra == 'runpod'
+  - passlib ; extra == 'runpod'
+  - pyjwt ; extra == 'runpod'
+  - aiohttp ; extra == 'runpod'
+  - anyio ; extra == 'runpod'
+  - grpcio>=1.63.0 ; extra == 'runpod'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'runpod'
+  - aiosqlite ; extra == 'runpod'
+  - casbin ; extra == 'fluidstack'
+  - sqlalchemy-adapter ; extra == 'fluidstack'
+  - passlib ; extra == 'fluidstack'
+  - pyjwt ; extra == 'fluidstack'
+  - aiohttp ; extra == 'fluidstack'
+  - anyio ; extra == 'fluidstack'
+  - grpcio>=1.63.0 ; extra == 'fluidstack'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'fluidstack'
+  - aiosqlite ; extra == 'fluidstack'
+  - cudo-compute>=0.1.10 ; extra == 'cudo'
+  - casbin ; extra == 'cudo'
+  - sqlalchemy-adapter ; extra == 'cudo'
+  - passlib ; extra == 'cudo'
+  - pyjwt ; extra == 'cudo'
+  - aiohttp ; extra == 'cudo'
+  - anyio ; extra == 'cudo'
+  - grpcio>=1.63.0 ; extra == 'cudo'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'cudo'
+  - aiosqlite ; extra == 'cudo'
+  - casbin ; extra == 'paperspace'
+  - sqlalchemy-adapter ; extra == 'paperspace'
+  - passlib ; extra == 'paperspace'
+  - pyjwt ; extra == 'paperspace'
+  - aiohttp ; extra == 'paperspace'
+  - anyio ; extra == 'paperspace'
+  - grpcio>=1.63.0 ; extra == 'paperspace'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'paperspace'
+  - aiosqlite ; extra == 'paperspace'
+  - casbin ; extra == 'primeintellect'
+  - sqlalchemy-adapter ; extra == 'primeintellect'
+  - passlib ; extra == 'primeintellect'
+  - pyjwt ; extra == 'primeintellect'
+  - aiohttp ; extra == 'primeintellect'
+  - anyio ; extra == 'primeintellect'
+  - grpcio>=1.63.0 ; extra == 'primeintellect'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'primeintellect'
+  - aiosqlite ; extra == 'primeintellect'
+  - pydo>=0.3.0 ; extra == 'do'
+  - azure-core>=1.24.0 ; extra == 'do'
+  - azure-common ; extra == 'do'
+  - casbin ; extra == 'do'
+  - sqlalchemy-adapter ; extra == 'do'
+  - passlib ; extra == 'do'
+  - pyjwt ; extra == 'do'
+  - aiohttp ; extra == 'do'
+  - anyio ; extra == 'do'
+  - grpcio>=1.63.0 ; extra == 'do'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'do'
+  - aiosqlite ; extra == 'do'
+  - vastai-sdk>=0.1.12 ; extra == 'vast'
+  - casbin ; extra == 'vast'
+  - sqlalchemy-adapter ; extra == 'vast'
+  - passlib ; extra == 'vast'
+  - pyjwt ; extra == 'vast'
+  - aiohttp ; extra == 'vast'
+  - anyio ; extra == 'vast'
+  - grpcio>=1.63.0 ; extra == 'vast'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'vast'
+  - aiosqlite ; extra == 'vast'
+  - pyvmomi==8.0.1.0.2 ; extra == 'vsphere'
+  - casbin ; extra == 'vsphere'
+  - sqlalchemy-adapter ; extra == 'vsphere'
+  - passlib ; extra == 'vsphere'
+  - pyjwt ; extra == 'vsphere'
+  - aiohttp ; extra == 'vsphere'
+  - anyio ; extra == 'vsphere'
+  - grpcio>=1.63.0 ; extra == 'vsphere'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'vsphere'
+  - aiosqlite ; extra == 'vsphere'
+  - awscli>=1.27.10 ; extra == 'vastdata'
+  - botocore>=1.29.10 ; extra == 'vastdata'
+  - boto3>=1.26.1 ; extra == 'vastdata'
+  - colorama<0.4.7 ; extra == 'vastdata'
+  - casbin ; extra == 'vastdata'
+  - sqlalchemy-adapter ; extra == 'vastdata'
+  - passlib ; extra == 'vastdata'
+  - pyjwt ; extra == 'vastdata'
+  - aiohttp ; extra == 'vastdata'
+  - anyio ; extra == 'vastdata'
+  - grpcio>=1.63.0 ; extra == 'vastdata'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'vastdata'
+  - aiosqlite ; extra == 'vastdata'
+  - nebius>=0.3.59 ; extra == 'nebius'
+  - grpcio>=1.63.0 ; extra == 'nebius'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'nebius'
+  - awscli>=1.27.10 ; extra == 'nebius'
+  - botocore>=1.29.10 ; extra == 'nebius'
+  - boto3>=1.26.1 ; extra == 'nebius'
+  - colorama<0.4.7 ; extra == 'nebius'
+  - casbin ; extra == 'nebius'
+  - sqlalchemy-adapter ; extra == 'nebius'
+  - passlib ; extra == 'nebius'
+  - pyjwt ; extra == 'nebius'
+  - aiohttp ; extra == 'nebius'
+  - anyio ; extra == 'nebius'
+  - grpcio>=1.63.0 ; extra == 'nebius'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'nebius'
+  - aiosqlite ; extra == 'nebius'
+  - casbin ; extra == 'hyperbolic'
+  - sqlalchemy-adapter ; extra == 'hyperbolic'
+  - passlib ; extra == 'hyperbolic'
+  - pyjwt ; extra == 'hyperbolic'
+  - aiohttp ; extra == 'hyperbolic'
+  - anyio ; extra == 'hyperbolic'
+  - grpcio>=1.63.0 ; extra == 'hyperbolic'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'hyperbolic'
+  - aiosqlite ; extra == 'hyperbolic'
+  - ecsapi==0.4.0 ; extra == 'seeweb'
+  - casbin ; extra == 'seeweb'
+  - sqlalchemy-adapter ; extra == 'seeweb'
+  - passlib ; extra == 'seeweb'
+  - pyjwt ; extra == 'seeweb'
+  - aiohttp ; extra == 'seeweb'
+  - anyio ; extra == 'seeweb'
+  - grpcio>=1.63.0 ; extra == 'seeweb'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'seeweb'
+  - aiosqlite ; extra == 'seeweb'
+  - casbin ; extra == 'mithril'
+  - sqlalchemy-adapter ; extra == 'mithril'
+  - passlib ; extra == 'mithril'
+  - pyjwt ; extra == 'mithril'
+  - aiohttp ; extra == 'mithril'
+  - anyio ; extra == 'mithril'
+  - grpcio>=1.63.0 ; extra == 'mithril'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'mithril'
+  - aiosqlite ; extra == 'mithril'
+  - casbin ; extra == 'shadeform'
+  - sqlalchemy-adapter ; extra == 'shadeform'
+  - passlib ; extra == 'shadeform'
+  - pyjwt ; extra == 'shadeform'
+  - aiohttp ; extra == 'shadeform'
+  - anyio ; extra == 'shadeform'
+  - grpcio>=1.63.0 ; extra == 'shadeform'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'shadeform'
+  - aiosqlite ; extra == 'shadeform'
+  - python-hostlist ; extra == 'slurm'
+  - casbin ; extra == 'slurm'
+  - sqlalchemy-adapter ; extra == 'slurm'
+  - passlib ; extra == 'slurm'
+  - pyjwt ; extra == 'slurm'
+  - aiohttp ; extra == 'slurm'
+  - anyio ; extra == 'slurm'
+  - grpcio>=1.63.0 ; extra == 'slurm'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'slurm'
+  - aiosqlite ; extra == 'slurm'
+  - casbin ; extra == 'yotta'
+  - sqlalchemy-adapter ; extra == 'yotta'
+  - passlib ; extra == 'yotta'
+  - pyjwt ; extra == 'yotta'
+  - aiohttp ; extra == 'yotta'
+  - anyio ; extra == 'yotta'
+  - grpcio>=1.63.0 ; extra == 'yotta'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'yotta'
+  - aiosqlite ; extra == 'yotta'
+  - casbin ; extra == 'verda'
+  - sqlalchemy-adapter ; extra == 'verda'
+  - passlib ; extra == 'verda'
+  - pyjwt ; extra == 'verda'
+  - aiohttp ; extra == 'verda'
+  - anyio ; extra == 'verda'
+  - grpcio>=1.63.0 ; extra == 'verda'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'verda'
+  - aiosqlite ; extra == 'verda'
+  - passlib ; extra == 'all'
+  - pycares<5 ; extra == 'all'
+  - msrestazure ; extra == 'all'
+  - ecsapi==0.4.0 ; extra == 'all'
+  - azure-core>=1.31.0 ; extra == 'all'
+  - google-cloud-storage ; extra == 'all'
+  - azure-storage-blob>=12.23.1 ; extra == 'all'
+  - runpod>=1.6.1 ; extra == 'all'
+  - azure-mgmt-compute>=33.0.0 ; extra == 'all'
+  - anyio ; extra == 'all'
+  - aiohttp ; extra == 'all'
+  - tomli ; extra == 'all'
+  - oci ; extra == 'all'
+  - huggingface-hub>=1.5,<1.9 ; python_full_version < '3.10' and extra == 'all'
+  - ibm-cloud-sdk-core ; extra == 'all'
+  - grpcio>=1.63.0 ; extra == 'all'
+  - sqlalchemy-adapter ; extra == 'all'
+  - pydo>=0.3.0 ; extra == 'all'
+  - aiosqlite ; extra == 'all'
+  - botocore>=1.29.10 ; extra == 'all'
+  - huggingface-hub>=1.5 ; python_full_version >= '3.10' and extra == 'all'
+  - azure-core>=1.24.0 ; extra == 'all'
+  - msgraph-sdk ; extra == 'all'
+  - websockets ; extra == 'all'
+  - boto3>=1.26.1 ; extra == 'all'
+  - kubernetes>=20.0.0,!=32.0.0,<36.0.0 ; extra == 'all'
+  - nebius>=0.3.59 ; extra == 'all'
+  - azure-mgmt-network>=27.0.0 ; extra == 'all'
+  - cudo-compute>=0.1.10 ; extra == 'all'
+  - azure-cli>=2.65.0,<2.87.0 ; extra == 'all'
+  - azure-common ; extra == 'all'
+  - ibm-platform-services>=0.48.0 ; extra == 'all'
+  - pyopenssl>=23.2.0 ; extra == 'all'
+  - python-hostlist ; extra == 'all'
+  - python-dateutil ; extra == 'all'
+  - ray[default]>=2.6.1 ; extra == 'all'
+  - awscli>=1.27.10 ; extra == 'all'
+  - ibm-vpc ; extra == 'all'
+  - pyvmomi==8.0.1.0.2 ; extra == 'all'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'all'
+  - pyjwt ; extra == 'all'
+  - google-api-python-client>=2.69.0 ; extra == 'all'
+  - docker ; extra == 'all'
+  - casbin ; extra == 'all'
+  - vastai-sdk>=0.1.12 ; extra == 'all'
+  - colorama<0.4.7 ; extra == 'all'
+  - ibm-cos-sdk ; extra == 'all'
+  - azure-identity>=1.19.0 ; extra == 'all'
+  - grpcio>=1.63.0 ; extra == 'remote'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'remote'
+  - casbin ; extra == 'server'
+  - sqlalchemy-adapter ; extra == 'server'
+  - passlib ; extra == 'server'
+  - pyjwt ; extra == 'server'
+  - aiohttp ; extra == 'server'
+  - anyio ; extra == 'server'
+  - grpcio>=1.63.0 ; extra == 'server'
+  - protobuf>=5.29.6,<7.0.0 ; extra == 'server'
+  - aiosqlite ; extra == 'server'
+- pypi: https://files.pythonhosted.org/packages/cc/a3/c2b0333c2716fb3b4c9a973dd113366ac51b4f8d56b500f4f8f704b4817a/setproctitle-1.3.7-cp310-cp310-macosx_11_0_arm64.whl
+  name: setproctitle
+  version: 1.3.7
+  sha256: 690b4776f9c15aaf1023bb07d7c5b797681a17af98a4a69e76a1d504e41108b7
+  requires_dist:
+  - pytest ; extra == 'test'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/ce/0e/ea0f4a563253b6363195a4f704123c6bfbf156641bd3be5a75de81c5e917/orjson-3.12.0-cp310-cp310-win_amd64.whl
   name: orjson
   version: 3.12.0
   sha256: 3bb17a06f9bd15237b3216c044209fe92597379124018cfc196fbb846cde64df
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl
+  name: wcmatch
+  version: 11.0.1
+  sha256: fd149ecddb9f0a88ea780017d6dde17c994e494e7f7303d4e3c9d6251f978f4b
+  requires_dist:
+  - bracex>=3.0
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/cf/35/819eeb4fa8ee676d38fdbb8213a76fd496f7dbbfdfafa89d34e02b22dfac/orjson-3.12.0-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
   name: orjson
   version: 3.12.0
   sha256: 747843254519dd43b93eee3153a19e5a509334320c4d2f823ec879232db5c796
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/cf/c1/165f10f2e37978caf92a1dca71726e7cd5d8de4039f9f4a6d1994a9b8d7f/pendulum-3.2.0-cp310-cp310-win_amd64.whl
+  name: pendulum
+  version: 3.2.0
+  sha256: 446f63d84ef21281844ceb45141536d3aabe291a821b6505e21a0d0e3ea95d67
+  requires_dist:
+  - python-dateutil>=2.6
+  - tzdata>=2020.1
+  - time-machine>=2.6.0,<3.0.0 ; implementation_name != 'pypy' and extra == 'test'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d0/98/1a853f6870ac7ad48383a948c8ff3c85dc278066a4d69fc9af7d3d4b1106/asyncpg-0.31.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: asyncpg
+  version: 0.31.0
+  sha256: 8ea599d45c361dfbf398cb67da7fd052affa556a401482d3ff1ee99bd68808a1
+  requires_dist:
+  - async-timeout>=4.0.3 ; python_full_version < '3.11'
+  - gssapi ; sys_platform != 'win32' and extra == 'gssauth'
+  - sspilib ; sys_platform == 'win32' and extra == 'gssauth'
+  requires_python: '>=3.9.0'
 - pypi: https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl
   name: cuda-toolkit
   version: 13.0.3.0
@@ -22447,6 +26512,64 @@ packages:
   - nvidia-cuda-opencl==13.0.85.* ; (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'opencl') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'opencl')
   - nvidia-cuda-profiler-api==13.0.85.* ; (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'profiler') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'profiler') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'profiler')
   - nvidia-cuda-sanitizer-api==13.0.85.* ; (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'sanitizer') or (platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'sanitizer') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'sanitizer')
+- pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+  name: colorama
+  version: 0.4.6
+  sha256: 4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*'
+- pypi: https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl
+  name: uvicorn
+  version: 0.35.0
+  sha256: 197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a
+  requires_dist:
+  - click>=7.0
+  - h11>=0.8
+  - typing-extensions>=4.0 ; python_full_version < '3.11'
+  - colorama>=0.4 ; sys_platform == 'win32' and extra == 'standard'
+  - httptools>=0.6.3 ; extra == 'standard'
+  - python-dotenv>=0.13 ; extra == 'standard'
+  - pyyaml>=5.1 ; extra == 'standard'
+  - uvloop>=0.15.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'
+  - watchfiles>=0.13 ; extra == 'standard'
+  - websockets>=10.4 ; extra == 'standard'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d3/5e/3a662f35ab7a9aa44a7c943335dabfbcc9ea6fa4921909aec4c6996dea4c/seisbench-0.12.5-cp310-cp310-macosx_11_0_arm64.whl
+  name: seisbench
+  version: 0.12.5
+  sha256: fbae977cde47c17285a5ca9de792b96157822ced64e0bee9cf78d8d9be1b0246
+  requires_dist:
+  - numpy>=1.21.6
+  - pandas>=1.1
+  - h5py>=3.1
+  - obspy>=1.3.1
+  - tqdm>=4.52
+  - torch>=1.10.0
+  - scipy>=1.9
+  - nest-asyncio>=1.5.3
+  - bottleneck>=1.3
+  - typing-extensions>=4.0
+  - xdas>=0.2.8 ; extra == 'das'
+  - pyarrow ; extra == 'das'
+  - torchvision ; extra == 'das'
+  - ruff ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - pytest ; extra == 'tests'
+  - pytest-asyncio>=0.26.0 ; extra == 'tests'
+  - pytest-benchmark ; extra == 'tests'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d3/f2/98eeac7d60c43df9338287834edf9b3e69be68a2db78a57b1b81d705e735/psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl
+  name: psycopg2-binary
+  version: 2.9.12
+  sha256: d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d4/9a/1ce5760d35a04a992006dd2f79afff2db548f93ee7426fa95c9f1fc90c61/grpcio-1.83.0-cp310-cp310-macosx_11_0_universal2.whl
+  name: grpcio
+  version: 1.83.0
+  sha256: 6755ed67cc3e454d51ae9f6e1915b80d3942fa4de956ef48dacd45ab7f40b727
+  requires_dist:
+  - typing-extensions~=4.12
+  - grpcio-tools>=1.83.0 ; extra == 'protobuf'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/d5/fa/f9e8b816e7d55b98777126cc38ad986a314bd86d258b6af01c09512a2ff1/pymseed-0.9.5-cp310-cp310-macosx_10_9_x86_64.whl
   name: pymseed
   version: 0.9.5
@@ -22482,6 +26605,74 @@ packages:
   - tornado>=4.5 ; extra == 'test'
   - typeguard ; extra == 'test'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/dc/fe/dd206cc19a25561921456f6cb12b405635319299b6f366e0bebe872abc18/setproctitle-1.3.7-cp310-cp310-win_amd64.whl
+  name: setproctitle
+  version: 1.3.7
+  sha256: a97200acc6b64ec4cada52c2ecaf1fba1ef9429ce9c542f8a7db5bcaa9dcbd95
+  requires_dist:
+  - pytest ; extra == 'test'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/dd/6e/d674f1dde91c71e2ac19e5e5cf1ee6d5845e3aefecd9c39ed9c4b0c9a696/pulp-3.3.2-py3-none-any.whl
+  name: pulp
+  version: 3.3.2
+  sha256: 631b166f72086971a9597f7a0233ababa99bb8d50a01cd543f7758be5a9f86c0
+  requires_dist:
+  - cbcbox ; extra == 'cbc'
+  - highspy==1.13 ; extra == 'open-py'
+  - pyscipopt ; extra == 'open-py'
+  - gurobipy ; extra == 'public-py'
+  - coptpy ; extra == 'public-py'
+  - xpress ; extra == 'public-py'
+  - cplex ; (python_full_version < '3.12' and extra == 'public-py') or (sys_platform != 'darwin' and extra == 'public-py')
+  - highspy==1.13 ; extra == 'highs'
+  - pyscipopt ; extra == 'scip'
+  - gurobipy ; extra == 'gurobi'
+  - xpress ; extra == 'xpress'
+  - coptpy ; extra == 'copt'
+  - cplex ; (python_full_version < '3.12' and extra == 'cplex') or (sys_platform != 'darwin' and extra == 'cplex')
+  - mosek ; extra == 'mosek'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz
+  name: cryptography
+  version: 50.0.0
+  sha256: eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9
+  requires_dist:
+  - cffi>=2.0.0 ; platform_python_implementation != 'PyPy'
+  - typing-extensions>=4.13.2 ; python_full_version < '3.11'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  requires_python: '!=3.9.0,>=3.9,!=3.9.1'
+- pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
+  name: python-multipart
+  version: 0.0.32
+  sha256: ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e1/13/775b5b79cb686dc9f9133f1f73079102e312866500556c1b604f72e7b68b/awscli-1.46.0-py3-none-any.whl
+  name: awscli
+  version: 1.46.0
+  sha256: 0aa98754c23c7eff4c7d970cb619670dc9b0214ee451bb3fe88e74e4a9a03a90
+  requires_dist:
+  - docutils>=0.18.1,<=0.19
+  - pyyaml>=3.10,<6.1
+  - colorama>=0.2.5,<0.4.7
+  - rsa>=3.1.2,<4.8
+  - jmespath>=0.7.1,<2.0.0
+  - python-dateutil>=2.1,<3.0.0
+  - urllib3>=1.25.4,!=2.2.0,<3
+  - awscrt==0.36.0 ; extra == 'crt'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e1/e3/0f15da0fb5864a37637820e4bde463a52ba0c052a8edab06aad46b9e578b/pycasbin-2.8.0-py3-none-any.whl
+  name: pycasbin
+  version: 2.8.0
+  sha256: 1a9e370de553c677c4dff75a5d6f3b0eb354b73b20d7df77ff4ee61a71267a3a
+  requires_dist:
+  - simpleeval>=1.0.3
+  - wcmatch>=10.1
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/e3/1e/2942a0d6d52240d439f44384a40c65d359d9ca70325b65b265c020113121/cuda_pathfinder-1.6.1-py3-none-any.whl
+  name: cuda-pathfinder
+  version: 1.6.1
+  sha256: cc8ec4cb0881fa5bcbf96b6dd75d50e55352b74dd33d4f3d884e192e7c2b6ef8
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/e4/b9/d3d7708a5d7641e2a1fa703c69c5ad10334a6ced4c0bd46486c1f69871f1/pyocto-0.1.4-cp310-cp310-macosx_10_9_universal2.macosx_10_9_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl
   name: pyocto
   version: 0.1.4
@@ -22494,6 +26685,16 @@ packages:
   - pyrocko>=2023.6.29 ; extra == 'test'
   - pyarrow>=12.0.1 ; extra == 'test'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl
+  name: cachetools
+  version: 7.1.7
+  sha256: ef98ef375ad188819ef2f9b3645e3987f4b8c5b7550e436ad998c2de78296df0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e6/e4/77487e14fc7be47180fd0eb4267c7486d0cc59b74031839a3daf8650136b/httptools-0.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: httptools
+  version: 0.8.0
+  sha256: a6f21e2a3b0067bbe7f67e34cfd16276af556e5e52f4c7503be0cb5f90e905e4
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl
   name: pydantic-core
   version: 2.46.4
@@ -22501,11 +26702,87 @@ packages:
   requires_dist:
   - typing-extensions>=4.14.1
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e9/93/0c0f002031f18b53af7a6166103c02b9c0667be528944137cc954ec921b3/rsa-4.7.2-py3-none-any.whl
+  name: rsa
+  version: 4.7.2
+  sha256: 78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2
+  requires_dist:
+  - pyasn1>=0.1.3
+  requires_python: '>=3.5,<4'
+- pypi: https://files.pythonhosted.org/packages/ea/03/f93b5e543f65c5f504e91405e8d21bb9e600548be95032951a754781a41d/asyncpg-0.31.0-cp310-cp310-macosx_11_0_arm64.whl
+  name: asyncpg
+  version: 0.31.0
+  sha256: 0b17c89312c2f4ccea222a3a6571f7df65d4ba2c0e803339bfc7bed46a96d3be
+  requires_dist:
+  - async-timeout>=4.0.3 ; python_full_version < '3.11'
+  - gssapi ; sys_platform != 'win32' and extra == 'gssauth'
+  - sspilib ; sys_platform == 'win32' and extra == 'gssauth'
+  requires_python: '>=3.9.0'
+- pypi: https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl
+  name: uvloop
+  version: 0.22.1
+  sha256: ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c
+  requires_dist:
+  - aiohttp>=3.10.5 ; extra == 'test'
+  - flake8~=6.1 ; extra == 'test'
+  - psutil ; extra == 'test'
+  - pycodestyle~=2.11.0 ; extra == 'test'
+  - pyopenssl~=25.3.0 ; extra == 'test'
+  - mypy>=0.800 ; extra == 'test'
+  - setuptools>=60 ; extra == 'dev'
+  - cython~=3.0 ; extra == 'dev'
+  - sphinx~=4.1.2 ; extra == 'docs'
+  - sphinxcontrib-asyncio~=0.3.0 ; extra == 'docs'
+  - sphinx-rtd-theme~=0.5.2 ; extra == 'docs'
+  requires_python: '>=3.8.1'
+- pypi: https://files.pythonhosted.org/packages/ec/ef/a707b5830722e9f7af347945f9ee0f360d38922366bc1400c6177154eb9c/ijson-3.5.1-cp310-cp310-win_amd64.whl
+  name: ijson
+  version: 3.5.1
+  sha256: 0663f718c6123899c6bfd9c449ec195cd8c67666b7ea2c7b36fa0cc0dcb13e17
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl
+  name: gitpython
+  version: 3.1.59
+  sha256: 67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c
+  requires_dist:
+  - gitdb>=4.0.1,<5
+  - typing-extensions>=3.10.0.2 ; python_full_version < '3.10'
+  - coverage[toml] ; extra == 'test'
+  - basedpyright==1.39.9 ; python_full_version >= '3.9' and sys_platform != 'cygwin' and extra == 'test'
+  - ddt>=1.1.1,!=1.4.3 ; extra == 'test'
+  - mock ; python_full_version < '3.8' and extra == 'test'
+  - mypy==1.18.2 ; python_full_version >= '3.9' and extra == 'test'
+  - pre-commit ; extra == 'test'
+  - pytest>=7.3.1 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-instafail ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - pytest-sugar ; extra == 'test'
+  - typing-extensions ; python_full_version < '3.11' and extra == 'test'
+  - sphinx>=7.4.7,<8 ; extra == 'doc'
+  - sphinx-rtd-theme ; extra == 'doc'
+  - sphinx-autodoc-typehints ; extra == 'doc'
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/f0/8e/ce9a23590cac33a6c24e6386cc0ffc55821cc13212acc822e98f00a67161/grpcio-1.83.0-cp310-cp310-win_amd64.whl
+  name: grpcio
+  version: 1.83.0
+  sha256: 8f6c395e493d20c39b29392ca200e9aaeb78d0bc2f04db0c0a7da7ddc939aa57
+  requires_dist:
+  - typing-extensions~=4.12
+  - grpcio-tools>=1.83.0 ; extra == 'protobuf'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
   name: nvidia-nvjitlink
   version: 13.3.33
   sha256: 26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/f2/48/fb401ec8c4953d519d05c87feca816ad668b8258448ff60579ac7a1c1386/setproctitle-1.3.7-cp310-cp310-macosx_10_9_universal2.whl
+  name: setproctitle
+  version: 1.3.7
+  sha256: cf555b6299f10a6eb44e4f96d2f5a3884c70ce25dc5c8796aaa2f7b40e72cb1b
+  requires_dist:
+  - pytest ; extra == 'test'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/f2/f9/44c8108722acb8613752107131146c75a27b1be554c0a1bb0868a5700fb2/pymseed-0.9.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: pymseed
   version: 0.9.5
@@ -22529,6 +26806,40 @@ packages:
   - build>=0.10.0 ; extra == 'release'
   - twine>=4.0.0 ; extra == 'release'
   - pymseed[dev,docs] ; extra == 'all'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/f3/18/a17e2f0cde02dc10154c808deed7e1d8528afff93612f70d3f0a5b19b011/websockets-16.1.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: websockets
+  version: 16.1.1
+  sha256: 1214e673c404684b9bf7154f5cf43b45025b1a6160fac3a9e438e9c1a97e22cb
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl
+  name: pip
+  version: 26.2.1
+  sha256: 71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/f7/a2/c8bf64a5d8d2e8506ccd09addb76b7a240cb8b1a5b67e9b814dc5c17eec7/seisbench-0.12.5-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: seisbench
+  version: 0.12.5
+  sha256: e6dee88496b2f97175f576e440a28e99c68a0094b5c5c1c4804f8c8e2b534efb
+  requires_dist:
+  - numpy>=1.21.6
+  - pandas>=1.1
+  - h5py>=3.1
+  - obspy>=1.3.1
+  - tqdm>=4.52
+  - torch>=1.10.0
+  - scipy>=1.9
+  - nest-asyncio>=1.5.3
+  - bottleneck>=1.3
+  - typing-extensions>=4.0
+  - xdas>=0.2.8 ; extra == 'das'
+  - pyarrow ; extra == 'das'
+  - torchvision ; extra == 'das'
+  - ruff ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - pytest ; extra == 'tests'
+  - pytest-asyncio>=0.26.0 ; extra == 'tests'
+  - pytest-benchmark ; extra == 'tests'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: nvidia-cusparse
@@ -22554,3 +26865,13 @@ packages:
   - email-validator>=2.0.0 ; extra == 'email'
   - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl
+  name: prettytable
+  version: 3.18.0
+  sha256: b3346e0e6f79180833aebaac088ae926340586cf6d7d991b9eb125b65f72313a
+  requires_dist:
+  - wcwidth>=0.3.5
+  - pytest-cov ; extra == 'tests'
+  - pytest-lazy-fixtures ; extra == 'tests'
+  - pytest>=9 ; extra == 'tests'
+  requires_python: '>=3.10'

--- a/pixi.lock
+++ b/pixi.lock
@@ -203,6 +203,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py310hb9dbd67_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.5.5-py310hea6c23e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.13.0-cpu_mkl_py310_h4f736ff_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-cpu-2.13.0-cpu_mkl_hd61e0f4_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
@@ -281,6 +282,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -444,6 +446,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -683,6 +686,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.2.2-py310h489c87a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.1-py310h805e0b6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.20-hea035f4_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.5.5-py310hf92f864_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pytorch-2.13.0-cpu_mkl_py310_hd240983_102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pytorch-cpu-2.13.0-cpu_mkl_h963eb49_102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.3-py310hec06124_1.conda
@@ -760,6 +764,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -1001,6 +1006,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.2.2-py310h52cee4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.1-py310h5b9b180_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-hac0b6dc_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.5.5-py310h22dadfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.13.0-cpu_generic_py310_hf21bd59_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-cpu-2.13.0-cpu_generic_hcc7c195_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py310hb46c203_1.conda
@@ -1076,6 +1082,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -1325,6 +1332,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.1-py310h61ea1ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.1-py310h059d4f2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.20-hc20f281_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.5.5-py310h73ae2b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pytorch-2.13.0-cpu_mkl_py310_h4cef612_102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pytorch-cpu-2.13.0-cpu_mkl_hf38594e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-312-py310h282bd7d_0.conda
@@ -1552,6 +1560,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py310hb9dbd67_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.5.5-py310hea6c23e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py310ha71cbf4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
@@ -1625,6 +1634,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -1804,6 +1814,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
@@ -2026,6 +2037,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.2.2-py310h489c87a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.1-py310h805e0b6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.20-hea035f4_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.5.5-py310hf92f864_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.3-py310hec06124_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-27.1.0-py310h30bd05a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
@@ -2103,6 +2115,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
@@ -2327,6 +2340,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.2.2-py310h52cee4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.1-py310h5b9b180_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-hac0b6dc_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.5.5-py310h22dadfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py310hb46c203_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py310hf396ece_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
@@ -2404,6 +2418,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -2642,6 +2657,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.1-py310h61ea1ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.1-py310h059d4f2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.20-hc20f281_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.5.5-py310h73ae2b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-312-py310h282bd7d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-3.0.5-py310h9e98ed7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py310hdb0e946_1.conda
@@ -2869,6 +2885,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.2-py310ha8dd31c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.5.5-py310hea6c23e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py310ha71cbf4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
@@ -2942,6 +2959,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -3173,6 +3191,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
@@ -3395,6 +3414,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.2.2-py310h489c87a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.1-py310h805e0b6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.20-hea035f4_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.5.5-py310hf92f864_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.3-py310hec06124_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-27.1.0-py310h30bd05a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
@@ -3524,6 +3544,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
@@ -3748,6 +3769,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.2.2-py310h52cee4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.1-py310h5b9b180_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-hac0b6dc_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.5.5-py310h22dadfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py310hb46c203_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py310hf396ece_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
@@ -3877,6 +3899,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -4110,6 +4133,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.1-py310h61ea1ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.2-py310h059d4f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.20-hc20f281_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.5.5-py310h73ae2b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-312-py310h282bd7d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-3.0.5-py310h9e98ed7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py310hdb0e946_1.conda
@@ -4399,6 +4423,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py310hb9dbd67_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.5.5-py310hea6c23e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pytokens-0.4.1-py310h139afa4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.13.0-cpu_mkl_py310_h4f736ff_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-cpu-2.13.0-cpu_mkl_hd61e0f4_102.conda
@@ -4482,6 +4507,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -4653,6 +4679,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -4897,6 +4924,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.2.2-py310h489c87a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.1-py310h805e0b6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.20-hea035f4_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.5.5-py310hf92f864_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pytokens-0.4.1-py310h5afac17_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pytorch-2.13.0-cpu_mkl_py310_hd240983_102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pytorch-cpu-2.13.0-cpu_mkl_h963eb49_102.conda
@@ -4979,6 +5007,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -5225,6 +5254,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.2.2-py310h52cee4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.1-py310h5b9b180_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-hac0b6dc_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.5.5-py310h22dadfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytokens-0.4.1-py310haea493c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.13.0-cpu_generic_py310_hf21bd59_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-cpu-2.13.0-cpu_generic_hcc7c195_2.conda
@@ -5304,6 +5334,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -5558,6 +5589,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.1-py310h61ea1ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.1-py310h059d4f2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.20-hc20f281_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.5.5-py310h73ae2b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pytokens-0.4.1-py310h1637853_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pytorch-2.13.0-cpu_mkl_py310_h4cef612_102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pytorch-cpu-2.13.0-cpu_mkl_hf38594e_102.conda
@@ -5797,6 +5829,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py310hb9dbd67_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.5.5-py310hea6c23e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.13.0-cpu_mkl_py310_h4f736ff_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-cpu-2.13.0-cpu_mkl_hd61e0f4_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
@@ -5875,6 +5908,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -6038,6 +6072,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -6277,6 +6312,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.2.2-py310h489c87a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.1-py310h805e0b6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.20-hea035f4_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.5.5-py310hf92f864_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pytorch-2.13.0-cpu_mkl_py310_hd240983_102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pytorch-cpu-2.13.0-cpu_mkl_h963eb49_102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.3-py310hec06124_1.conda
@@ -6354,6 +6390,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -6595,6 +6632,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.2.2-py310h52cee4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.1-py310h5b9b180_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-hac0b6dc_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.5.5-py310h22dadfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.13.0-cpu_generic_py310_hf21bd59_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-cpu-2.13.0-cpu_generic_hcc7c195_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py310hb46c203_1.conda
@@ -6670,6 +6708,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -6919,6 +6958,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.1-py310h61ea1ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.1-py310h059d4f2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.20-hc20f281_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.5.5-py310h73ae2b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pytorch-2.13.0-cpu_mkl_py310_h4cef612_102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pytorch-cpu-2.13.0-cpu_mkl_hf38594e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-312-py310h282bd7d_0.conda
@@ -7162,6 +7202,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py310hb9dbd67_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.5.5-py310hea6c23e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.13.0-cpu_mkl_py310_h4f736ff_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py310ha71cbf4_3.conda
@@ -7240,6 +7281,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -7417,6 +7459,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
@@ -7671,6 +7714,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.1-py310h61ea1ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.1-py310h059d4f2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.20-hc20f281_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.5.5-py310h73ae2b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pytorch-2.13.0-cpu_mkl_py310_h4cef612_102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-312-py310h282bd7d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-3.0.5-py310h9e98ed7_0.conda
@@ -11248,6 +11292,22 @@ packages:
     - python
   size: 25403213
   timestamp: 1781149348162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.5.5-py310hea6c23e_0.conda
+  sha256: d5381587807db718af5cada47df0b06e1e92eea436aaf9cc36da2f0e46e72318
+  md5: 6c41e80529869aeb222ba368a1082115
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/duckdb?source=hash-mapping
+  run_exports: {}
+  size: 17132295
+  timestamp: 1784912776301
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pytokens-0.4.1-py310h139afa4_2.conda
   sha256: 6e74e99787870ee4158165dacd312347342a8cdf67814086365c4fe95512151b
   md5: 1874447dc9421e6fa984853d5df7ec2a
@@ -12875,6 +12935,17 @@ packages:
   run_exports: {}
   size: 24062
   timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.5.5-hff2d567_0.conda
+  sha256: 943cce538b2530bf9ac709998cf5b21489ef7bbbcddc106f0b82d0dc3c3123e4
+  md5: 3ddb4bae3847f91eb949c10978e2bbdb
+  depends:
+  - python-duckdb >=1.5.5,<1.5.6.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 7771
+  timestamp: 1784912831431
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
   sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
   md5: 8e662bd460bda79b1ea39194e3c4c9ab
@@ -17386,6 +17457,21 @@ packages:
     - python
   size: 13071051
   timestamp: 1781151393975
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.5.5-py310hf92f864_0.conda
+  sha256: a934ff1e9f148638f2d8915c6328f205094358eaa2ec4b3d0b3405d7cc81f32b
+  md5: 77cc3e18ce834c86b4ca7086849b9cd5
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/duckdb?source=hash-mapping
+  run_exports: {}
+  size: 13702488
+  timestamp: 1784914028929
 - conda: https://conda.anaconda.org/conda-forge/osx-64/pytokens-0.4.1-py310h5afac17_2.conda
   sha256: c75f3d6f4a557fe5194e7b05bdeb74b46e02c7b981dfdcf594615c8257897284
   md5: ee0375e6d9a34c77aab0101d72ecc06e
@@ -20348,6 +20434,21 @@ packages:
     - python
   size: 12888297
   timestamp: 1781148720732
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.5.5-py310h22dadfc_0.conda
+  sha256: 96906d2a4879cdb5609e1ee0db01355a788c7573084ec52164fe84fe88d5387b
+  md5: 40430ed5d3757d2472e08249efb10ac4
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/duckdb?source=hash-mapping
+  run_exports: {}
+  size: 11982479
+  timestamp: 1784912248958
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytokens-0.4.1-py310haea493c_2.conda
   sha256: c206a60bc36854a564326ea8700a0872ad40894198936215157ff6e2a6e43c7a
   md5: 2325f389bd730f3d3aa88a7e1036e26a
@@ -23651,6 +23752,22 @@ packages:
     - python
   size: 16128204
   timestamp: 1781148776322
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.5.5-py310h73ae2b4_0.conda
+  sha256: d052a293452bc5e987629b8f6f618124cf3a0a351f02c4791d13234793414e40
+  md5: c1c58683644293bba0c0545587a5ac0a
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/duckdb?source=hash-mapping
+  run_exports: {}
+  size: 10217225
+  timestamp: 1784914387239
 - conda: https://conda.anaconda.org/conda-forge/win-64/pytokens-0.4.1-py310h1637853_2.conda
   sha256: f466f73332170cf53e304d130d5c6f89c7b4dc4d13cbc030451b70814f1b3a13
   md5: e666f35f5d912d94d57790424701dcee

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "quakescope"
-version = "2.0.0"
+version = "3.0.0"
 description = "Machine learning seismic phase picking at cloud scale"
 authors = ["Yiyu Ni <niyiyu@uw.edu>", "Jannes Munchmeyer <munchmej@univ-grenoble-alpes.fr>", "Marine Denolle <mdenolle@uw.edu>"]
 channels = ["conda-forge", "pytorch", "nvidia"]
@@ -42,6 +42,11 @@ platforms = ["linux-64", "win-64"]
 pytorch = ">=2.1"
 pytorch-cuda = "==11.8"
 
+[feature.deploy.pypi-dependencies]
+# SkyPilot provisions and recovers the Spot workers. Pinned to the AWS extra;
+# the jobs controller is what gives managed jobs their preemption recovery.
+skypilot = { version = ">=0.10", extras = ["aws"] }
+
 [feature.dev.dependencies]
 pytest = ">=7.0"
 black = ">=23.0"
@@ -52,6 +57,11 @@ tutorials = ["cpu"]
 tutorials-gpu = ["gpu"]
 cloud = ["cpu"]
 dev = ["cpu", "dev"]
+deploy = ["deploy"]
+
+[feature.deploy.tasks]
+plan = "python -m sb_catalog.src.shard_planner"
+progress = "python -c \"import sys;from sb_catalog.src.s3_state import S3CampaignState;print(S3CampaignState(sys.argv[1]).progress())\""
 
 [tasks]
 watch = "python scripts/aws_watch.py"

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,6 +24,9 @@ ipykernel = ">=6.20.0"
 tqdm = ">=4.65.0"
 requests = ">=2.31.0"
 pyarrow = ">=14"
+# Reading the Parquet catalogue: partition pruning and predicate pushdown over
+# S3 without loading a campaign into memory. Used by notebooks/6_check_parquet.
+duckdb = ">=0.10"
 joblib = ">=1.3"
 
 [pypi-dependencies]

--- a/sb_catalog/Dockerfile
+++ b/sb_catalog/Dockerfile
@@ -9,7 +9,9 @@ WORKDIR /code
 RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 
 # SeisBench
-RUN pip install seisbench pyocto ipython s3fs pymongo boto3==1.35.81 tqdm joblib earthscope-sdk==1.0.0b0
+# pyarrow is required by parquet_writer, which is the v3 output path - without
+# it a picking job ImportErrors before it reads a byte.
+RUN pip install seisbench pyocto ipython s3fs pymongo boto3==1.35.81 tqdm joblib earthscope-sdk==1.0.0b0 pyarrow
 
 # get AWS DocumentDB public key
 RUN wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem

--- a/sb_catalog/src/parquet_writer.py
+++ b/sb_catalog/src/parquet_writer.py
@@ -257,6 +257,32 @@ class ParquetPickWriter:
         })
         buffers[key] = []
 
+    def checkpoint(self) -> list[dict]:
+        """Flush every buffered partition and report what is now durable.
+
+        Exists so a preempted shard does not start over. Picks are buffered
+        until :meth:`close`, so without this a Spot interruption twelve hours
+        into a shard loses twelve hours of work. Flushing periodically bounds
+        that loss to the checkpoint interval.
+
+        Returns the station-day-channel records covered by everything written so
+        far. The caller records them **after** this returns, never before: the
+        ordering is what stops a resume skipping station-days whose picks were
+        never actually written.
+        """
+        for key in list(self._picks):
+            self._write_partition("picks", key, PICK_SCHEMA, self._picks)
+        for key in list(self._classifies):
+            self._write_partition(
+                "classifies", key, CLASSIFY_SCHEMA, self._classifies
+            )
+        return list(self._records)
+
+    @property
+    def pending_records(self) -> int:
+        """Station-day-channels handled so far, flushed or not."""
+        return len(self._records)
+
     def close(self) -> dict:
         """Write everything still buffered, plus a manifest for the job."""
         for key in list(self._picks):

--- a/sb_catalog/src/parquet_writer.py
+++ b/sb_catalog/src/parquet_writer.py
@@ -39,7 +39,11 @@ from typing import Any, Optional
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+
+import fsspec
 import s3fs
+
+from .profiling import stage
 
 logger = logging.getLogger("picker")
 
@@ -108,7 +112,15 @@ class ParquetPickWriter:
         self.job_id = job_id or self._infer_job_id()
         self.compression = compression
         self.flush_threshold = flush_threshold
-        self.fs = s3fs.S3FileSystem(**(storage_options or {}))
+        # Pick the filesystem from the URI scheme rather than assuming S3, so a
+        # local root works for tests and dry runs - which _ensure_parent already
+        # claimed to support, but could not, because this was hardcoded.
+        if self.root.startswith("s3://"):
+            self.fs = s3fs.S3FileSystem(**(storage_options or {}))
+        else:
+            self.fs = fsspec.filesystem(
+                fsspec.utils.get_protocol(self.root), **(storage_options or {})
+            )
 
         self._picks: dict[tuple, list] = defaultdict(list)
         self._classifies: dict[tuple, list] = defaultdict(list)
@@ -116,6 +128,8 @@ class ParquetPickWriter:
         self._part_seq: dict[tuple, int] = defaultdict(int)
         self.n_picks = 0
         self.n_classifies = 0
+        # Object keys written by this job, so readers never have to LIST.
+        self._written: list[dict] = []
 
     @staticmethod
     def _infer_job_id() -> str:
@@ -219,13 +233,28 @@ class ParquetPickWriter:
         suffix = f"-{seq:03d}.parquet" if seq else ".parquet"
         path = self._partition_path(kind, key, suffix)
 
-        table = pa.Table.from_pylist(rows, schema=schema)
+        # Encode and upload are timed apart: one is CPU on the worker, the other
+        # is network to S3, and they scale with different things. The comparison
+        # against DocumentDB's per-station-day insert_many needs both.
+        with stage("parquet.encode", unit=len(rows), unit_name="row"):
+            table = pa.Table.from_pylist(rows, schema=schema)
         self._ensure_parent(path)
-        with self.fs.open(path, "wb") as fh:
-            pq.write_table(
-                table, fh, compression=self.compression, use_dictionary=True
-            )
+        with stage("parquet.put", unit=len(rows), unit_name="row"):
+            with self.fs.open(path, "wb") as fh:
+                pq.write_table(
+                    table, fh, compression=self.compression, use_dictionary=True
+                )
         logger.info(f"Wrote {len(rows):>8} {kind} rows -> {path}")
+        # Record what was written, with the partition key and row count. This is
+        # what lets a reader locate a job's output with GETs alone: without it
+        # the only way to find these objects is to LIST the partition, because
+        # the file name carries a content hash and a flush sequence number that
+        # a reader cannot reconstruct.
+        network, year, month = key
+        self._written.append({
+            "kind": kind, "path": path, "rows": len(rows),
+            "network": network, "year": year, "month": month,
+        })
         buffers[key] = []
 
     def close(self) -> dict:
@@ -244,6 +273,7 @@ class ParquetPickWriter:
             "n_classifies": self.n_classifies,
             "station_days": len(self._records),
             "written_at": datetime.datetime.utcnow().isoformat() + "Z",
+            "files": self._written,
             "records": self._records,
         }
         # One manifest per job, flat rather than partitioned: it describes the

--- a/sb_catalog/src/picker.py
+++ b/sb_catalog/src/picker.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import functools
 import logging
+import sys
 import time
 from typing import Optional
 
@@ -17,6 +18,7 @@ from bson import ObjectId
 from .amplitude_extractor import AmplitudeExtractor
 from .classifier import QuakeXNet
 from .parquet_writer import ParquetPickWriter
+from .profiling import stage
 from .s3_helper import S3DataSource
 from .utils import SeisBenchDatabase, parse_year_day
 
@@ -27,11 +29,23 @@ def main() -> None:
     """
     This main function serves as the entry point to all functionality available in the script.
     """
+    # `work` delegates to the v3 queue worker. The container's ENTRYPOINT is
+    # fixed at `python -m src.picker`, and AWS Batch's containerProperties has no
+    # entryPoint field, so on Fargate this subcommand is the only way to reach
+    # the worker without publishing a second image. Dispatched before argparse
+    # because the worker takes a completely different set of options - notably
+    # no --db_uri, since v3 has no database.
+    if len(sys.argv) > 1 and sys.argv[1] == "work":
+        from .worker import main as worker_main
+
+        return worker_main(sys.argv[2:])
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "command",
         type=str,
-        help="Subroutine to execute. See below for available functions.",
+        help="Subroutine to execute. See below for available functions. "
+        "Use `work` to run the v3 S3-queue worker instead of a single job.",
     )
     parser.add_argument(
         "--db_uri", type=str, required=True, help="URI of the MongoDB cluster."
@@ -194,6 +208,7 @@ class S3MongoSBBridge:
         extent: Optional[tuple[float, float, float, float]] = None,
         classifier: Optional[bool] = False,
         parquet_uri: Optional[str] = None,
+        job_id: Optional[str] = None,
     ):
         self.extent = extent
         # When set, bulk picks go to Parquet on S3 instead of into the
@@ -202,7 +217,11 @@ class S3MongoSBBridge:
         # docs/rerun_2026/12_output_storage.md.
         # Batch always supplies the parameter, so an empty string is how "no
         # Parquet output" arrives from a job definition.
-        self.parquet_uri = parquet_uri or None
+        self.parquet_uri = parquet_uri
+        # Names the Parquet object. Without it ParquetPickWriter falls back to
+        # HOSTNAME, and every shard a node runs writes the SAME key inside a
+        # (network, year, month) partition - silently overwriting the last.
+        self.job_id = job_id or None
         self._parquet = None
 
         # model preparation
@@ -256,7 +275,7 @@ class S3MongoSBBridge:
             return None
         if self._parquet is None:
             self._parquet = ParquetPickWriter(
-                root=self.parquet_uri, run_id=str(self.run_id)
+                root=self.parquet_uri, run_id=str(self.run_id), job_id=self.job_id
             )
         return self._parquet
 
@@ -426,22 +445,33 @@ class S3MongoSBBridge:
                 )
             else:
                 # do picking
-                stream_annotations = await asyncio.to_thread(
-                    self.model.classify, stream
-                )
-                # extract amplitudes
-                stream_amplitudes = await asyncio.to_thread(
-                    self.amp_extor.extract_amplitudes,
-                    stream,
-                    stream_annotations.picks,
-                    self.s3.inventory,
-                )
+                def _classify():
+                    with stage("model.classify"):
+                        return self.model.classify(stream)
+
+                stream_annotations = await asyncio.to_thread(_classify)
+                n_picks = len(stream_annotations.picks)
+
+                # extract amplitudes. Timed against PICK COUNT, not station-days:
+                # this pass runs once per pick and pick counts vary ~4x between an
+                # ordinary day and a mainshock day, so per-station-day timing hides
+                # how it actually scales.
+                def _amps():
+                    with stage("amp.wood_anderson", unit=n_picks, unit_name="pick"):
+                        return self.amp_extor.extract_amplitudes(
+                            stream, stream_annotations.picks, self.s3.inventory
+                        )
+
+                stream_amplitudes = await asyncio.to_thread(_amps)
+
                 # extract raw amplitudes around each pick
-                stream_raw_amplitudes = await asyncio.to_thread(
-                    self.amp_extor.extract_raw_amplitudes,
-                    stream,
-                    stream_annotations.picks,
-                )
+                def _raw_amps():
+                    with stage("amp.raw", unit=n_picks, unit_name="pick"):
+                        return self.amp_extor.extract_raw_amplitudes(
+                            stream, stream_annotations.picks
+                        )
+
+                stream_raw_amplitudes = await asyncio.to_thread(_raw_amps)
 
                 # classifier
                 if self.classifier and (channel in ["BH", "HH"]):

--- a/sb_catalog/src/picker.py
+++ b/sb_catalog/src/picker.py
@@ -5,7 +5,7 @@ import functools
 import logging
 import sys
 import time
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import obspy
@@ -209,6 +209,8 @@ class S3MongoSBBridge:
         classifier: Optional[bool] = False,
         parquet_uri: Optional[str] = None,
         job_id: Optional[str] = None,
+        checkpoint_every: int = 0,
+        on_checkpoint: Optional[Any] = None,
     ):
         self.extent = extent
         # When set, bulk picks go to Parquet on S3 instead of into the
@@ -217,11 +219,21 @@ class S3MongoSBBridge:
         # docs/rerun_2026/12_output_storage.md.
         # Batch always supplies the parameter, so an empty string is how "no
         # Parquet output" arrives from a job definition.
-        self.parquet_uri = parquet_uri
+        # `or None` matters: Batch always supplies the parameter, so "no Parquet
+        # output" arrives as an empty string, and the writer would otherwise be
+        # constructed with an empty root.
+        self.parquet_uri = parquet_uri or None
         # Names the Parquet object. Without it ParquetPickWriter falls back to
         # HOSTNAME, and every shard a node runs writes the SAME key inside a
         # (network, year, month) partition - silently overwriting the last.
-        self.job_id = job_id or None
+        self.job_id = job_id
+        # Flush and record progress every N station-day-channels, so a Spot
+        # preemption costs at most that much rather than the whole shard.
+        # 0 disables it, which is the right default for the database path where
+        # every station-day is committed as it completes anyway.
+        self.checkpoint_every = int(checkpoint_every or 0)
+        self.on_checkpoint = on_checkpoint
+        self._next_checkpoint = self.checkpoint_every
         self._parquet = None
 
         # model preparation
@@ -593,11 +605,30 @@ class S3MongoSBBridge:
             )
 
         if writer is not None:
-            # In Parquet mode the picks are buffered until the job ends, so
-            # committing picks_record here would let a Spot interruption strand
-            # station-days that are marked done but were never written. The
-            # records are held with the picks and committed together once the
-            # flush has succeeded; see _finalise_parquet.
+            # In Parquet mode the picks are buffered, so committing picks_record
+            # here would let a Spot interruption strand station-days that are
+            # marked done but were never written. Records are committed only
+            # after a flush succeeds - either at a checkpoint below, or in
+            # _finalise_parquet at the end of the job.
+            #
+            # Checkpointing exists so a preemption does not discard the whole
+            # shard: at 40 stations x 20 days a shard runs about twelve hours,
+            # and without this every one of those hours is lost. Flush first,
+            # then report, never the reverse.
+            if (
+                self.checkpoint_every
+                and self.on_checkpoint is not None
+                and writer.pending_records >= self._next_checkpoint
+            ):
+                records = writer.checkpoint()
+                self.on_checkpoint(records)
+                self._next_checkpoint = (
+                    writer.pending_records + self.checkpoint_every
+                )
+                logger.info(
+                    f"Checkpointed {len(records)} station-day-channels; a "
+                    f"preemption now costs at most {self.checkpoint_every}"
+                )
             return
 
         self.db.insert_many_ignore_duplicates(

--- a/sb_catalog/src/profiling.py
+++ b/sb_catalog/src/profiling.py
@@ -1,0 +1,131 @@
+"""
+Per-stage timing for one shard, so cost can be attributed rather than guessed.
+
+The v3 cost model was built on a single wall-clock number per station-day and an
+assumption that inference dominated it. That assumption was never tested, and the
+pipeline has at least six stages that scale with different things: S3 LIST scales
+with objects in a day prefix, GET with bytes, inference with samples, and the two
+amplitude passes with *pick count* - which varies fourfold between an ordinary
+day and a mainshock day.
+
+Each stage records seconds, how many times it ran, and the quantity it scales
+with (bytes, picks, windows), because a stage that is slow per call and a stage
+that is called far too often need different fixes.
+
+Disabled by default and costs a boolean check per call site, so instrumentation
+can live in the real code path instead of a parallel harness that drifts from it.
+
+Usage:
+    from .profiling import profile, stage
+
+    profile.enable()
+    with stage("s3.get", bytes=n):
+        ...
+    print(profile.report())
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from typing import Optional
+
+
+class Profile:
+    """Thread-safe stage accumulator. One per process."""
+
+    def __init__(self) -> None:
+        self.enabled = False
+        self._lock = threading.Lock()
+        self._seconds: dict[str, float] = defaultdict(float)
+        self._calls: dict[str, int] = defaultdict(int)
+        self._units: dict[str, float] = defaultdict(float)
+        self._unit_name: dict[str, str] = {}
+        self._t0: Optional[float] = None
+
+    def enable(self) -> None:
+        self.enabled = True
+        self._t0 = time.perf_counter()
+
+    def reset(self) -> None:
+        with self._lock:
+            self._seconds.clear()
+            self._calls.clear()
+            self._units.clear()
+            self._unit_name.clear()
+        self._t0 = time.perf_counter()
+
+    def record(self, name: str, seconds: float, unit: float, unit_name: str) -> None:
+        with self._lock:
+            self._seconds[name] += seconds
+            self._calls[name] += 1
+            self._units[name] += unit
+            if unit_name:
+                self._unit_name[name] = unit_name
+
+    def elapsed(self) -> float:
+        return time.perf_counter() - self._t0 if self._t0 is not None else 0.0
+
+    def report(self) -> str:
+        """Stage table, slowest first, with the share of wall-clock accounted for.
+
+        The unaccounted line is the point of the whole exercise: if the stages do
+        not add up to wall-clock, something expensive is not instrumented yet.
+        """
+        with self._lock:
+            rows = sorted(self._seconds.items(), key=lambda kv: -kv[1])
+            total = self.elapsed()
+            acct = sum(self._seconds.values())
+            out = [
+                "",
+                f"{'stage':26s} {'seconds':>9s} {'%wall':>6s} {'calls':>8s} "
+                f"{'s/call':>9s} {'per unit':>18s}",
+                "-" * 84,
+            ]
+            for name, sec in rows:
+                calls = self._calls[name]
+                units = self._units[name]
+                uname = self._unit_name.get(name, "")
+                per_unit = ""
+                if uname and units:
+                    if uname == "bytes":
+                        per_unit = f"{units / sec / 1e6:.1f} MB/s" if sec else ""
+                    else:
+                        per_unit = f"{sec / units * 1000:.3f} ms/{uname}"
+                out.append(
+                    f"{name:26s} {sec:9.2f} {100 * sec / total if total else 0:6.1f} "
+                    f"{calls:8d} {sec / calls if calls else 0:9.3f} {per_unit:>18s}"
+                )
+            out += [
+                "-" * 84,
+                f"{'accounted':26s} {acct:9.2f} {100 * acct / total if total else 0:6.1f}",
+                f"{'wall clock':26s} {total:9.2f} {100.0:6.1f}",
+                f"{'UNACCOUNTED':26s} {total - acct:9.2f} "
+                f"{100 * (total - acct) / total if total else 0:6.1f}",
+                "",
+            ]
+            # Totals the cost model actually needs, spelled out.
+            for name, uname in self._unit_name.items():
+                if uname == "bytes":
+                    out.append(f"  {name}: {self._units[name] / 1e6:,.1f} MB transferred")
+                elif uname in ("pick", "window"):
+                    out.append(f"  {name}: {int(self._units[name]):,} {uname}s")
+            return "\n".join(out)
+
+
+profile = Profile()
+
+
+@contextmanager
+def stage(name: str, unit: float = 0.0, unit_name: str = ""):
+    """Time a stage. A no-op beyond a boolean check when profiling is off."""
+    if not profile.enabled:
+        yield
+        return
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        profile.record(name, time.perf_counter() - t0, unit, unit_name)

--- a/sb_catalog/src/s3_helper.py
+++ b/sb_catalog/src/s3_helper.py
@@ -16,9 +16,14 @@ from obspy.clients.fdsn.header import FDSNNoDataException
 from s3fs import S3FileSystem
 
 from .constants import NETWORK_MAPPING
+from .profiling import stage
 from .utils import SeisBenchDatabase
 
-EARTHSCOPE_S3_ACCESS_POINT = os.environ["EARTHSCOPE_S3_ACCESS_POINT"]
+# Default to empty rather than KeyError at import: parameters.py has always
+# defaulted this to "" for campaigns that never touch EarthScope, and the
+# module is imported by every picking job regardless of archive.
+EARTHSCOPE_S3_ACCESS_POINT = os.environ.get("EARTHSCOPE_S3_ACCESS_POINT", "")
+ES_CREDENTIAL_ATTEMPTS = int(os.environ.get("ES_CREDENTIAL_ATTEMPTS", "5"))
 
 logger = logging.getLogger("picker")
 
@@ -84,12 +89,23 @@ class CompositeS3ObjectHelper(S3ObjectHelper):
         }
 
         self.ttl_threshold = datetime.timedelta(minutes=5)
-        self.credential = self.get_es_credential()
         self.fs = {
             "scedc": S3FileSystem(anon=True),
             "ncedc": S3FileSystem(anon=True),
         }
-        self.set_es_filesystem()
+        # EarthScope needs credentials; SCEDC and NCEDC are anonymous. Skip the
+        # credential exchange entirely when the campaign has not been configured
+        # for EarthScope, so a public-bucket run neither stalls nor fails on it.
+        self.earthscope_enabled = bool(EARTHSCOPE_S3_ACCESS_POINT)
+        self.credential = None
+        if self.earthscope_enabled:
+            self.credential = self.get_es_credential()
+            self.set_es_filesystem()
+        else:
+            logger.info(
+                "EARTHSCOPE_S3_ACCESS_POINT is unset - EarthScope access disabled, "
+                "using the public SCEDC/NCEDC buckets only"
+            )
 
     def get_prefix(self, net, year, day) -> str:
         return self.helpers[self.get_data_center(net)].get_prefix(net, year, day)
@@ -109,17 +125,30 @@ class CompositeS3ObjectHelper(S3ObjectHelper):
         """
         Set 5 minutes buffer time to update credential
         """
-        while True:
+        last = None
+        for attempt in range(1, ES_CREDENTIAL_ATTEMPTS + 1):
             try:
                 with EarthScopeClient() as client:
                     return client.user.get_aws_credentials(
                         ttl_threshold=self.ttl_threshold
                     )
-            except:
+            except Exception as exc:
+                last = exc
                 logger.warning(
-                    f"EarthScope credential client might be busy. Sleep for 5 seconds and retry."
+                    f"EarthScope credential client might be busy "
+                    f"({attempt}/{ES_CREDENTIAL_ATTEMPTS}): {type(exc).__name__}. "
+                    f"Sleeping 5 seconds."
                 )
                 time.sleep(5)
+        # Fail rather than retry forever. An unbounded loop here never completes
+        # and never errors, so a Spot worker holds its shard until the lease
+        # expires and the next worker inherits the same hang.
+        raise RuntimeError(
+            f"Could not obtain EarthScope credentials after "
+            f"{ES_CREDENTIAL_ATTEMPTS} attempts. Set ES_OAUTH2__REFRESH_TOKEN and "
+            f"EARTHSCOPE_S3_ACCESS_POINT, or restrict the campaign to the public "
+            f"SCEDC/NCEDC buckets."
+        ) from last
 
     def set_es_filesystem(self):
         self.fs["earthscope"] = S3FileSystem(
@@ -129,6 +158,10 @@ class CompositeS3ObjectHelper(S3ObjectHelper):
         )
 
     def update_es_filesystem(self):
+        # No-op when EarthScope was never configured: self.credential is None and
+        # dereferencing it would AttributeError on the first refresh check.
+        if not getattr(self, "earthscope_enabled", True) or self.credential is None:
+            return
         if (
             self.credential.expiration - datetime.datetime.now(tz=datetime.timezone.utc)
         ) < self.ttl_threshold:
@@ -202,7 +235,12 @@ class S3DataSource:
                     net, day.strftime("%Y"), day.strftime("%j")
                 )
                 try:
-                    avail_uri[net] += fs.ls(prefix)
+                    # One LIST per day per network. A SCEDC day prefix holds
+                    # ~4,000 objects, so this is not free and is paid again for
+                    # every day in the shard.
+                    with stage("s3.list"):
+                        listing = fs.ls(prefix)
+                    avail_uri[net] += listing
                 except FileNotFoundError:
                     logger.debug(f"Path does not exist {prefix}")
                     pass
@@ -287,13 +325,20 @@ class S3DataSource:
         while True:
             fs = self.s3helper.get_filesystem(net)
             try:
-                bytes_mb = fs.info(uri)["size"] / 1024**2
+                # Separately timed: this is a HEAD round trip before every GET,
+                # which is pure latency and doubles the request count.
+                with stage("s3.head"):
+                    size = fs.info(uri)["size"]
+                bytes_mb = size / 1024**2
                 if self.limit_mb is not None and bytes_mb > self.limit_mb:
                     logger.warning(f"mSEED is too big (%.3f MB): %s" % (bytes_mb, uri))
                     return obspy.Stream()
                 else:
-                    buff = io.BytesIO(fs.read_bytes(uri))
-                    return obspy.read(buff)
+                    with stage("s3.get", unit=size, unit_name="bytes"):
+                        raw = fs.read_bytes(uri)
+                    buff = io.BytesIO(raw)
+                    with stage("mseed.parse", unit=size, unit_name="bytes"):
+                        return obspy.read(buff)
             except OSError as e:
                 if e.errno == 5:
                     logger.warning(f"Not authorized to access this resource: {uri}")

--- a/sb_catalog/src/s3_state.py
+++ b/sb_catalog/src/s3_state.py
@@ -120,11 +120,45 @@ class S3CampaignState:
             raise
 
     def _get_json(self, key: str) -> Optional[dict]:
+        obj, _ = self._get_json_etag(key)
+        return obj
+
+    def _get_json_etag(self, key: str) -> tuple[Optional[dict], Optional[str]]:
+        """The object and its ETag, for compare-and-swap on an existing key."""
         try:
-            return json.loads(self.s3.get_object(Bucket=self.bucket, Key=key)["Body"].read())
+            r = self.s3.get_object(Bucket=self.bucket, Key=key)
+            return json.loads(r["Body"].read()), r.get("ETag")
         except ClientError as exc:
             if exc.response.get("Error", {}).get("Code") in ("NoSuchKey", "404"):
-                return None
+                return None, None
+            raise
+
+    def _replace_json(self, key: str, obj: dict, etag: str) -> bool:
+        """Overwrite a key only if it still holds `etag`.
+
+        The compare-and-swap half of the claim protocol. Taking over a stale
+        claim with a plain PUT looks safe but is not: two workers that observe
+        the same stale claim at the same moment would both succeed, both believe
+        they own the shard, and both write the same Parquet key - one silently
+        overwriting the other. IfMatch makes the takeover a single winner.
+        """
+        try:
+            self.s3.put_object(
+                Bucket=self.bucket, Key=key,
+                Body=json.dumps(obj, indent=2).encode(),
+                ContentType="application/json",
+                IfMatch=etag,
+            )
+            return True
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in ("PreconditionFailed", "ConditionalRequestConflict"):
+                return False        # someone else took it first
+            if code == "NotImplemented":
+                raise RuntimeError(
+                    "This S3 endpoint does not support conditional overwrite "
+                    "(IfMatch), so a stale claim cannot be taken over safely."
+                ) from exc
             raise
 
     def _exists(self, key: str) -> bool:
@@ -218,8 +252,10 @@ class S3CampaignState:
 
         # A claim exists. It is only ours to take if it went stale without ever
         # producing a manifest - which is what a Spot preemption leaves behind.
-        existing = self._get_json(key)
-        if existing is None:
+        # The ETag is captured here so the takeover below can be a
+        # compare-and-swap rather than a blind overwrite.
+        existing, etag = self._get_json_etag(key)
+        if existing is None or etag is None:
             return False
         if self.is_complete(shard_id):
             return False
@@ -236,7 +272,13 @@ class S3CampaignState:
         )
         record["reclaimed_from"] = existing.get("worker")
         record["reclaimed_after_hours"] = round(age_h, 2)
-        self._put_json(key, record)          # unconditional: we won the stale race
+        # Compare-and-swap, not a plain PUT. Two workers can observe the same
+        # stale claim in the same instant; without IfMatch both would succeed and
+        # both would run the shard, writing the same Parquet key. Whoever loses
+        # the swap simply moves to the next shard.
+        if not self._replace_json(key, record, etag):
+            logger.info(f"Lost the race to reclaim {shard_id}; leaving it")
+            return False
         return True
 
     def read_progress(self, shard_id: str) -> set[tuple]:

--- a/sb_catalog/src/s3_state.py
+++ b/sb_catalog/src/s3_state.py
@@ -1,0 +1,280 @@
+"""
+S3-backed campaign state: the replacement for DocumentDB in v3.
+
+Everything the pipeline needs to keep between jobs now lives under one S3
+prefix, so a campaign has no provisioned database, no VPC to launch inside, and
+no endpoint to keep alive:
+
+    s3://<bucket>/<campaign>/
+        stations.parquet          station metadata          (was: stations)
+        shards.jsonl              the work queue            (new)
+        claims/<shard_id>.json    who is working on what    (new)
+        complete/<shard_id>.json  what finished             (was: picks_record)
+        manifests/<job_id>.json   what each job wrote       (ParquetPickWriter)
+        runs/<run_id>.json        provenance                (was: sb_runs)
+        picks/network=/year=/month=/*.parquet
+
+**Claiming is the part that makes Spot safe.** SkyPilot recovers a preempted
+managed job by relaunching it, so a worker can die mid-shard at any moment and
+another can start on the same queue seconds later. Claims are taken with an S3
+conditional write (`IfNoneMatch: "*"`), which fails if the key already exists -
+an atomic compare-and-set, so two workers can never take the same shard. A claim
+carries a timestamp and is reclaimable after `lease_hours` with no manifest,
+which is what returns work abandoned by a preemption to the queue.
+
+A shard is therefore in exactly one of three states, all readable from S3 alone:
+finished (manifest exists), in flight (fresh claim, no manifest), or available
+(no claim, or a stale one).
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+import socket
+from typing import Any, Iterator, Optional
+
+import boto3
+import pandas as pd
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger("s3_state")
+
+DEFAULT_LEASE_HOURS = 6.0
+
+
+def _split_uri(uri: str) -> tuple[str, str]:
+    """s3://bucket/a/b -> ("bucket", "a/b")"""
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Expected an s3:// URI, got {uri!r}")
+    body = uri[len("s3://"):].strip("/")
+    bucket, _, key = body.partition("/")
+    if not bucket:
+        raise ValueError(f"No bucket in {uri!r}")
+    return bucket, key
+
+
+def _utcnow() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+class ShardTaken(Exception):
+    """Another worker holds this shard."""
+
+
+class S3CampaignState:
+    """Campaign state on S3. One instance per campaign prefix."""
+
+    def __init__(
+        self,
+        root: str,
+        client: Any = None,
+        lease_hours: float = DEFAULT_LEASE_HOURS,
+    ) -> None:
+        self.root = root.rstrip("/")
+        self.bucket, self.prefix = _split_uri(self.root)
+        self.lease_hours = lease_hours
+        self.s3 = client if client is not None else boto3.client("s3")
+        self.worker_id = f"{socket.gethostname()}:{os.getpid()}"
+
+    # ---------------------------------------------------------------- paths
+    def _key(self, *parts: str) -> str:
+        return "/".join([p for p in (self.prefix, *parts) if p])
+
+    def uri(self, *parts: str) -> str:
+        return f"s3://{self.bucket}/{self._key(*parts)}"
+
+    # ------------------------------------------------------------ primitives
+    def _put_json(self, key: str, obj: dict, if_absent: bool = False) -> bool:
+        """Write JSON. With if_absent, returns False if the key already exists.
+
+        The conditional write is the atomic compare-and-set the claim protocol
+        rests on; S3 answers PreconditionFailed when another worker got there
+        first. Older S3-compatible endpoints may reject the header outright
+        (NotImplemented), which we surface rather than silently racing.
+        """
+        kwargs = dict(
+            Bucket=self.bucket,
+            Key=key,
+            Body=json.dumps(obj, indent=2).encode(),
+            ContentType="application/json",
+        )
+        if if_absent:
+            kwargs["IfNoneMatch"] = "*"
+        try:
+            self.s3.put_object(**kwargs)
+            return True
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if if_absent and code in ("PreconditionFailed", "ConditionalRequestConflict"):
+                return False
+            if if_absent and code == "NotImplemented":
+                raise RuntimeError(
+                    "This S3 endpoint does not support conditional writes "
+                    "(IfNoneMatch), so shard claims cannot be made atomic. "
+                    "Use AWS S3, or run with a single worker."
+                ) from exc
+            raise
+
+    def _get_json(self, key: str) -> Optional[dict]:
+        try:
+            return json.loads(self.s3.get_object(Bucket=self.bucket, Key=key)["Body"].read())
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") in ("NoSuchKey", "404"):
+                return None
+            raise
+
+    def _exists(self, key: str) -> bool:
+        try:
+            self.s3.head_object(Bucket=self.bucket, Key=key)
+            return True
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                return False
+            raise
+
+    def _list(self, sub: str) -> Iterator[str]:
+        paginator = self.s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=self._key(sub)):
+            for item in page.get("Contents", []):
+                yield item["Key"]
+
+    # -------------------------------------------------------------- stations
+    def write_stations(self, stations: pd.DataFrame) -> str:
+        """Persist station metadata. Replaces the `stations` collection."""
+        uri = self.uri("stations.parquet")
+        stations.to_parquet(uri, index=False)
+        logger.info(f"Wrote {len(stations)} stations to {uri}")
+        return uri
+
+    def get_stations(
+        self,
+        extent: tuple[float, float, float, float] | None = None,
+        network: str | None = None,
+    ) -> pd.DataFrame:
+        """Station metadata, filtered like SeisBenchDatabase.get_stations did."""
+        df = pd.read_parquet(self.uri("stations.parquet"))
+        if network:
+            wanted = {n.strip() for n in network.split(",") if n.strip()}
+            df = df[df["network_code"].isin(wanted)]
+        if extent:
+            minlat, maxlat, minlon, maxlon = extent
+            df = df[
+                df["latitude"].between(minlat, maxlat)
+                & df["longitude"].between(minlon, maxlon)
+            ]
+        return df.reset_index(drop=True)
+
+    # ------------------------------------------------------------------ runs
+    def write_run(self, run_id: str, **meta: Any) -> str:
+        """Provenance for one campaign run. Replaces `sb_runs`."""
+        self._put_json(self._key("runs", f"{run_id}.json"),
+                       {"run_id": run_id, "created": _utcnow(), **meta})
+        return self.uri("runs", f"{run_id}.json")
+
+    # ---------------------------------------------------------------- shards
+    def write_shards(self, shards: list[dict]) -> str:
+        """Write the immutable work queue. Refuses to clobber an existing one,
+        because shard ids are how completed work is recognised on resume."""
+        key = self._key("shards.jsonl")
+        if self._exists(key):
+            raise FileExistsError(
+                f"{self.uri('shards.jsonl')} already exists. The queue is immutable "
+                f"once a campaign starts - completed work is keyed on shard id. "
+                f"Use a new campaign prefix, or delete it deliberately."
+            )
+        body = "\n".join(json.dumps(s) for s in shards).encode()
+        self.s3.put_object(Bucket=self.bucket, Key=key, Body=body,
+                           ContentType="application/x-ndjson")
+        logger.info(f"Wrote {len(shards)} shards to {self.uri('shards.jsonl')}")
+        return self.uri("shards.jsonl")
+
+    def read_shards(self) -> list[dict]:
+        obj = self.s3.get_object(Bucket=self.bucket, Key=self._key("shards.jsonl"))
+        return [json.loads(l) for l in obj["Body"].read().decode().splitlines() if l.strip()]
+
+    def is_complete(self, shard_id: str) -> bool:
+        return self._exists(self._key("complete", f"{shard_id}.json"))
+
+    def completed_ids(self) -> set[str]:
+        """One LIST instead of one HEAD per shard - matters at 65k shards.
+
+        Reads `complete/`, deliberately NOT `manifests/`: ParquetPickWriter also
+        writes a per-job manifest, and sharing the prefix made its object look
+        like a finished shard, so resume skipped work that never ran.
+        """
+        n = len(self._key("complete")) + 1
+        return {k[n:-len(".json")] for k in self._list("complete/") if k.endswith(".json")}
+
+    def claim(self, shard_id: str) -> bool:
+        """Atomically take a shard. False if someone else holds a live claim."""
+        key = self._key("claims", f"{shard_id}.json")
+        record = {"shard_id": shard_id, "worker": self.worker_id, "claimed": _utcnow()}
+        if self._put_json(key, record, if_absent=True):
+            return True
+
+        # A claim exists. It is only ours to take if it went stale without ever
+        # producing a manifest - which is what a Spot preemption leaves behind.
+        existing = self._get_json(key)
+        if existing is None:
+            return False
+        if self.is_complete(shard_id):
+            return False
+        try:
+            claimed = datetime.datetime.fromisoformat(existing["claimed"])
+        except (KeyError, ValueError):
+            return False
+        age_h = (datetime.datetime.now(datetime.timezone.utc) - claimed).total_seconds() / 3600
+        if age_h < self.lease_hours:
+            return False
+        logger.warning(
+            f"Reclaiming {shard_id}: claim by {existing.get('worker')} is "
+            f"{age_h:.1f}h old (lease {self.lease_hours}h) with no manifest"
+        )
+        record["reclaimed_from"] = existing.get("worker")
+        record["reclaimed_after_hours"] = round(age_h, 2)
+        self._put_json(key, record)          # unconditional: we won the stale race
+        return True
+
+    def complete(self, shard_id: str, manifest: dict) -> str:
+        """Mark a shard done. Written only after its Parquet is durable."""
+        key = self._key("complete", f"{shard_id}.json")
+        self._put_json(key, {"shard_id": shard_id, "worker": self.worker_id,
+                             "completed": _utcnow(), **manifest})
+        return self.uri("complete", f"{shard_id}.json")
+
+    def heartbeat(self, shard_id: str) -> None:
+        """Refresh a claim's timestamp so a running shard is never reclaimed.
+
+        Without this the lease has to exceed the slowest possible shard, which
+        makes abandoned work sit in the queue for that long after a hard kill.
+        With it the lease can stay short: a live worker keeps saying so, and only
+        a genuinely dead one goes stale.
+        """
+        self._put_json(self._key("claims", f"{shard_id}.json"),
+                       {"shard_id": shard_id, "worker": self.worker_id,
+                        "claimed": _utcnow(), "heartbeat": True})
+
+    def release(self, shard_id: str) -> None:
+        """Drop a claim after a failure so the shard returns to the queue at once
+        rather than waiting out the lease."""
+        try:
+            self.s3.delete_object(Bucket=self.bucket,
+                                  Key=self._key("claims", f"{shard_id}.json"))
+        except ClientError as exc:      # not fatal: the lease still expires
+            logger.warning(f"Could not release {shard_id}: {exc}")
+
+    # ---------------------------------------------------------------- status
+    def progress(self) -> dict:
+        shards = self.read_shards()
+        done = self.completed_ids()
+        n = len(self._key("claims")) + 1
+        claimed = {k[n:-len(".json")] for k in self._list("claims/") if k.endswith(".json")}
+        return {
+            "total": len(shards),
+            "complete": len(done),
+            "in_flight": len(claimed - done),
+            "remaining": len(shards) - len(done),
+        }

--- a/sb_catalog/src/s3_state.py
+++ b/sb_catalog/src/s3_state.py
@@ -10,6 +10,7 @@ no endpoint to keep alive:
         shards.jsonl              the work queue            (new)
         claims/<shard_id>.json    who is working on what    (new)
         complete/<shard_id>.json  what finished             (was: picks_record)
+        progress/<shard_id>.json  mid-shard checkpoints     (new)
         manifests/<job_id>.json   what each job wrote       (ParquetPickWriter)
         runs/<run_id>.json        provenance                (was: sb_runs)
         picks/network=/year=/month=/*.parquet
@@ -248,10 +249,7 @@ class S3CampaignState:
         record = self._get_json(self._key("progress", f"{shard_id}.json"))
         if not record:
             return set()
-        return {
-            (r["tid"], r["yr"], r["doy"], r["cha"])
-            for r in record.get("records", [])
-        }
+        return {tuple(e) for e in record.get("done", [])}
 
     def write_progress(self, shard_id: str, records: list[dict]) -> None:
         """Record durable progress mid-shard.
@@ -260,10 +258,15 @@ class S3CampaignState:
         returned. Written the other way round, a resume would skip station-days
         whose picks were never stored - the same ordering trap as `complete`.
         """
+        # Identity only. The full records carry npks/nclfs/rid, which the final
+        # manifest needs but a resume does not, and this object is rewritten at
+        # every checkpoint - so carrying them would triple an O(n^2) write for
+        # no benefit.
+        done = [[r["tid"], r["yr"], r["doy"], r["cha"]] for r in records]
         self._put_json(
             self._key("progress", f"{shard_id}.json"),
             {"shard_id": shard_id, "worker": self.worker_id,
-             "updated": _utcnow(), "n": len(records), "records": records},
+             "updated": _utcnow(), "n": len(done), "done": done},
         )
 
     def complete(self, shard_id: str, manifest: dict) -> str:

--- a/sb_catalog/src/s3_state.py
+++ b/sb_catalog/src/s3_state.py
@@ -238,6 +238,34 @@ class S3CampaignState:
         self._put_json(key, record)          # unconditional: we won the stale race
         return True
 
+    def read_progress(self, shard_id: str) -> set[tuple]:
+        """Station-day-channels of this shard already written and recorded.
+
+        Returned as `(tid, yr, doy, cha)` tuples. A resumed shard skips these
+        instead of starting over, which is what keeps a preemption from costing
+        the whole shard - about twelve hours at the default grouping.
+        """
+        record = self._get_json(self._key("progress", f"{shard_id}.json"))
+        if not record:
+            return set()
+        return {
+            (r["tid"], r["yr"], r["doy"], r["cha"])
+            for r in record.get("records", [])
+        }
+
+    def write_progress(self, shard_id: str, records: list[dict]) -> None:
+        """Record durable progress mid-shard.
+
+        Only ever called *after* the Parquet flush that covers these records has
+        returned. Written the other way round, a resume would skip station-days
+        whose picks were never stored - the same ordering trap as `complete`.
+        """
+        self._put_json(
+            self._key("progress", f"{shard_id}.json"),
+            {"shard_id": shard_id, "worker": self.worker_id,
+             "updated": _utcnow(), "n": len(records), "records": records},
+        )
+
     def complete(self, shard_id: str, manifest: dict) -> str:
         """Mark a shard done. Written only after its Parquet is durable."""
         key = self._key("complete", f"{shard_id}.json")

--- a/sb_catalog/src/shard_planner.py
+++ b/sb_catalog/src/shard_planner.py
@@ -1,0 +1,132 @@
+"""
+Plan a campaign into shards and write the work queue to S3.
+
+This is the v3 replacement for `submit_helper.submit_pick_jobs`, minus the
+submitting: it does the same station/day grouping the 2025 campaign used - 40
+stations x 20 days per unit of work - but instead of calling `batch.submit_job`
+once per unit it writes the whole queue to `shards.jsonl` and stops. Workers
+then pull from that queue (see `worker.py`).
+
+Splitting planning from execution is what lets a preempted Spot worker be
+replaced without re-planning, and what makes a campaign resumable by inspecting
+S3 alone. The queue is immutable once written, because completed work is keyed
+on shard id.
+
+Usage:
+    python -m sb_catalog.src.shard_planner \\
+        --campaign s3://quakescope-picks-2026/scedc \\
+        --start 2019.001 --end 2019.365 \\
+        --network CI --stations s3://.../stations.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import logging
+
+import pandas as pd
+
+from .s3_state import S3CampaignState
+
+logger = logging.getLogger("shard_planner")
+
+STATION_GROUP_SIZE = 40      # as run in 2025
+DAY_GROUP_SIZE = 20
+
+
+def parse_year_day(x: str) -> datetime.date:
+    return datetime.datetime.strptime(x, "%Y.%j").date()
+
+
+def shard_id(stations: list[str], start: datetime.date, end: datetime.date) -> str:
+    """Stable id: same inputs always produce the same shard, so re-planning an
+    identical campaign recognises work that is already done."""
+    digest = hashlib.sha1(
+        ("|".join(sorted(stations)) + f"|{start:%Y.%j}|{end:%Y.%j}").encode()
+    ).hexdigest()[:12]
+    return f"{start:%Y%j}-{end:%Y%j}-{digest}"
+
+
+def plan(
+    stations: pd.DataFrame,
+    start: datetime.date,
+    end: datetime.date,
+    station_group_size: int = STATION_GROUP_SIZE,
+    day_group_size: int = DAY_GROUP_SIZE,
+) -> list[dict]:
+    """Group stations and days exactly as the 2025 Batch campaign did."""
+    ids = sorted(stations["id"].astype(str))
+    days = pd.date_range(start, end, freq="D")       # end inclusive
+    shards = []
+    for i in range(0, len(ids), station_group_size):
+        group = ids[i: i + station_group_size]
+        for j in range(0, len(days), day_group_size):
+            d0 = days[j].date()
+            # END IS EXCLUSIVE, matching S3DataSource.load_waveforms, which does
+            # np.arange(start, end). An inclusive end here silently drops the
+            # last day of every shard - 1 day in 20 at the default grouping.
+            last = days[min(j + day_group_size - 1, len(days) - 1)].date()
+            d1 = last + datetime.timedelta(days=1)
+            shards.append({
+                "shard_id": shard_id(group, d0, d1),
+                "stations": group,
+                "start": f"{d0:%Y.%j}",
+                "end": f"{d1:%Y.%j}",
+                "n_station_days": len(group) * (d1 - d0).days,
+            })
+    return shards
+
+
+def main(argv=None):
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+    )
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--campaign", required=True,
+                    help="s3://bucket/campaign - the campaign state prefix")
+    ap.add_argument("--start", required=True, type=parse_year_day, help="YYYY.DDD (inclusive)")
+    ap.add_argument("--end", required=True, type=parse_year_day, help="YYYY.DDD (inclusive)")
+    ap.add_argument("--stations", help="Parquet/CSV of station metadata to install "
+                                       "into the campaign before planning")
+    ap.add_argument("--network", help="Comma separated network codes")
+    ap.add_argument("--extent", help="minlat,maxlat,minlon,maxlon")
+    ap.add_argument("--station-group-size", type=int, default=STATION_GROUP_SIZE)
+    ap.add_argument("--day-group-size", type=int, default=DAY_GROUP_SIZE)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Report the plan without writing the queue")
+    args = ap.parse_args(argv)
+
+    state = S3CampaignState(args.campaign)
+
+    if args.stations:
+        df = (pd.read_parquet(args.stations) if args.stations.endswith(".parquet")
+              else pd.read_csv(args.stations))
+        state.write_stations(df)
+
+    extent = tuple(float(x) for x in args.extent.split(",")) if args.extent else None
+    stations = state.get_stations(extent=extent, network=args.network)
+    if stations.empty:
+        raise SystemExit("No stations matched - check --network/--extent against stations.parquet")
+
+    shards = plan(stations, args.start, args.end,
+                  args.station_group_size, args.day_group_size)
+    total_sd = sum(s["n_station_days"] for s in shards)
+    logger.info(
+        f"{len(stations)} stations x {(args.end - args.start).days + 1} days "
+        f"-> {len(shards)} shards, {total_sd:,} station-days"
+    )
+    if args.dry_run:
+        for s in shards[:3]:
+            logger.info(f"  e.g. {s['shard_id']}  {s['start']}..{s['end']}  "
+                        f"{len(s['stations'])} stations")
+        return
+
+    state.write_shards(shards)
+    logger.info(f"Queue ready. Launch workers against {args.campaign}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sb_catalog/src/worker.py
+++ b/sb_catalog/src/worker.py
@@ -1,0 +1,331 @@
+"""
+Pull shards from the S3 queue and pick them. The v3 execution unit.
+
+One worker loop claims a shard, runs the existing picking bridge over it, flushes
+Parquet, and writes the shard's manifest - in that order, so a manifest never
+exists for work whose picks are not durable. Then it takes the next shard. N
+loops run per node (`--procs`), and N nodes run per campaign, all against the
+same queue; the claim protocol in `s3_state` is what keeps them off each other.
+
+**Written for Spot.** Preemption arrives as SIGTERM with about two minutes'
+notice, so the loop installs a handler that releases the in-flight claim and
+exits, returning that shard to the queue immediately instead of making the next
+worker wait out the lease. Work already flushed is kept, because completion is
+per shard and recorded in S3. If the process is killed outright with no warning,
+the lease expiry covers it instead.
+
+There is no database. Station metadata, resume state and provenance all come
+from the campaign prefix - see `s3_state`.
+
+Usage (normally invoked by the SkyPilot template, not by hand):
+    python -m sb_catalog.src.worker \\
+        --campaign s3://quakescope-picks-2026/scedc \\
+        --weight jma_wc --procs 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import multiprocessing as mp
+import os
+import signal
+import sys
+import threading
+import time
+import uuid
+
+import pandas as pd
+
+from .profiling import profile
+from .s3_state import S3CampaignState
+
+logger = logging.getLogger("worker")
+
+
+class S3StateAdapter:
+    """The slice of the SeisBenchDatabase interface the picking path uses,
+    backed by campaign state on S3 instead of DocumentDB.
+
+    Only four methods are needed; association still requires a real database and
+    is not part of a v3 picking campaign.
+    """
+
+    def __init__(self, state: S3CampaignState, stations: pd.DataFrame):
+        self.state = state
+        self._stations = stations
+        self.picks_record: list[dict] = []
+        self.db_uri = state.root          # provenance strings expect these
+        self.database = None
+
+    def get_station_metadata(self, stations: list[str], key: dict = {}) -> pd.DataFrame:
+        return self._stations[self._stations["id"].isin(stations)].reset_index(drop=True)
+
+    def get_stations(self, extent=None, network=None) -> pd.DataFrame:
+        return self.state.get_stations(extent=extent, network=network)
+
+    def get_picks_record(self, station, day, channel, key: dict = {}):
+        """Always None: resume is per shard in v3, not per channel-day.
+
+        A shard only runs when it has no manifest, and a manifest is only written
+        after its Parquet is durable, so nothing inside a running shard has been
+        committed. Answering None avoids ~800 S3 HEAD requests per shard to learn
+        something the queue already knows.
+        """
+        return None
+
+    def write_run_data(self, **kwargs) -> str:
+        run_id = str(uuid.uuid4())
+        self.state.write_run(run_id, **{k: str(v) for k, v in kwargs.items()})
+        return run_id
+
+    def insert_many_ignore_duplicates(self, collection: str, records: list[dict]) -> None:
+        if collection == "picks_record":
+            self.picks_record.extend(records)
+        else:                              # picks/classifies go to Parquet in v3
+            logger.debug(f"Ignoring {len(records)} rows for '{collection}' (Parquet mode)")
+
+
+def _log_instance_lifecycle() -> None:
+    """Say whether this node is Spot or on-demand.
+
+    SkyPilot can satisfy a job on-demand without saying so, and a campaign run
+    for Spot pricing should not discover that in Cost Explorer a week later.
+    IMDSv2, short timeout, silent if unavailable (e.g. not on EC2).
+    """
+    try:
+        import urllib.request
+        def _req(url, headers, method="GET"):
+            r = urllib.request.Request(url, headers=headers, method=method)
+            return urllib.request.urlopen(r, timeout=2).read().decode()
+        tok = _req("http://169.254.169.254/latest/api/token",
+                   {"X-aws-ec2-metadata-token-ttl-seconds": "60"}, "PUT")
+        h = {"X-aws-ec2-metadata-token": tok}
+        itype = _req("http://169.254.169.254/latest/meta-data/instance-type", h)
+        try:
+            _req("http://169.254.169.254/latest/meta-data/spot/instance-action", h)
+            life = "spot"
+        except Exception as exc:                     # 404 = not interrupted yet
+            life = "spot" if "404" in str(exc) else "on-demand"
+        logger.info(f"Running on {itype} ({life})")
+        if life != "spot":
+            logger.warning(
+                "This node is ON-DEMAND, not Spot - roughly 3x the hourly price."
+            )
+    except Exception:
+        pass
+
+
+class Preempted(Exception):
+    """SIGTERM - Spot reclaim, or an operator stopping the job."""
+
+
+def _run_shard(shard: dict, args, state: S3CampaignState, stations: pd.DataFrame) -> dict:
+    """Pick one shard. Imports are local so a worker that never claims anything
+    does not pay for loading torch."""
+    from .picker import S3MongoSBBridge
+    from .s3_helper import S3DataSource
+    from .utils import parse_year_day
+
+    db = S3StateAdapter(state, stations)
+    # S3DataSource wants dates, not the "%Y.%j" strings the queue carries, and
+    # treats `end` as exclusive - the planner writes it that way.
+    s3 = S3DataSource(
+        stations=",".join(shard["stations"]),
+        start=parse_year_day(shard["start"]),
+        end=parse_year_day(shard["end"]),
+        components=args.components,
+        db=db,
+    )
+    bridge = S3MongoSBBridge(
+        s3=s3,
+        db=db,
+        model=args.model,
+        weight=args.weight,
+        p_threshold=args.p_threshold,
+        s_threshold=args.s_threshold,
+        data_queue_size=args.data_queue_size,
+        pick_queue_size=args.pick_queue_size,
+        extent=None,
+        classifier=False,          # the classifier is out for 2026
+        parquet_uri=args.parquet_uri or state.uri(),
+        # One Parquet object per shard. Anything less specific collides inside a
+        # (network, year, month) partition when a node runs many shards.
+        job_id=shard["shard_id"],
+    )
+    t0 = time.time()
+    bridge.run_picking()
+    return {
+        "stations": len(shard["stations"]),
+        "start": shard["start"],
+        "end": shard["end"],
+        "station_days": shard.get("n_station_days"),
+        "picks_record": len(db.picks_record),
+        "weight": args.weight,
+        "model": args.model,
+        "seconds": round(time.time() - t0, 1),
+    }
+
+
+def loop(args, proc_index: int = 0) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format=f"%(asctime)s | worker{proc_index} | %(levelname)s | %(message)s",
+    )
+    state = S3CampaignState(args.campaign, lease_hours=args.lease_hours)
+    state.worker_id = f"{os.uname().nodename}:{os.getpid()}"
+
+    holding = {"shard": None}
+
+    def on_term(signum, frame):
+        raise Preempted()
+
+    signal.signal(signal.SIGTERM, on_term)
+    signal.signal(signal.SIGINT, on_term)
+
+    _log_instance_lifecycle()
+    if args.profile:
+        profile.enable()
+        if args.procs > 1:
+            logger.warning(
+                "--profile with --procs %d: worker loops contend for the same "
+                "cores, so per-stage attribution will be distorted. Use --procs 1.",
+                args.procs,
+            )
+
+    shards = state.read_shards()
+    stations = state.get_stations()
+    done = state.completed_ids()
+    logger.info(
+        f"Queue {args.campaign}: {len(shards)} shards, {len(done)} already complete"
+    )
+
+    # Offsetting the start point keeps N processes from contending on the same
+    # head of the queue; the claim protocol would make it correct anyway, but
+    # this makes it cheap.
+    order = list(range(len(shards)))
+    if len(order):
+        off = (proc_index * 7919) % len(order)
+        order = order[off:] + order[:off]
+
+    n_done = n_failed = 0
+    try:
+        for idx in order:
+            shard = shards[idx]
+            sid = shard["shard_id"]
+            if sid in done or state.is_complete(sid):
+                continue
+            if not state.claim(sid):
+                continue
+            holding["shard"] = sid
+            logger.info(f"Claimed {sid} ({shard['start']}..{shard['end']}, "
+                        f"{len(shard['stations'])} stations)")
+            stop_beat = threading.Event()
+
+            def _beat():
+                # A 2025-sized shard runs ~23 h; the lease is hours. Refresh
+                # while alive so only a dead worker's claim ever goes stale.
+                while not stop_beat.wait(args.lease_hours * 3600 / 4):
+                    try:
+                        state.heartbeat(sid)
+                    except Exception as exc:
+                        logger.warning(f"Heartbeat failed for {sid}: {exc}")
+
+            beat = threading.Thread(target=_beat, daemon=True)
+            beat.start()
+            try:
+                manifest = _run_shard(shard, args, state, stations)
+            except Preempted:
+                stop_beat.set()
+                raise
+            except Exception as exc:
+                stop_beat.set()
+                n_failed += 1
+                logger.exception(f"Shard {sid} failed: {exc}")
+                state.release(sid)         # requeue at once rather than after the lease
+                holding["shard"] = None
+                if args.max_failures and n_failed >= args.max_failures:
+                    logger.error(f"Stopping after {n_failed} failures")
+                    break
+                continue
+            stop_beat.set()
+            state.complete(sid, manifest)
+            holding["shard"] = None
+            n_done += 1
+            logger.info(f"Completed {sid} in {manifest['seconds']}s "
+                        f"({manifest['picks_record']} station-day-channels)")
+            if args.profile:
+                # Printed per shard, not per campaign: the stage mix depends on
+                # pick count, which varies fourfold between an ordinary day and
+                # a sequence, so a single aggregate would hide the variation.
+                logger.info(f"stage profile for {sid}:{profile.report()}")
+                profile.reset()
+            if args.max_shards and n_done >= args.max_shards:
+                logger.info(f"Reached --max-shards {args.max_shards}")
+                break
+    except Preempted:
+        if holding["shard"]:
+            logger.warning(
+                f"Preempted while holding {holding['shard']} - releasing it back "
+                f"to the queue"
+            )
+            state.release(holding["shard"])
+        logger.info(f"Exiting on signal after {n_done} shards")
+        sys.exit(0)
+
+    logger.info(f"Queue drained for this worker: {n_done} shards done, {n_failed} failed")
+    if n_done == 0 and n_failed > 0:
+        # Exit non-zero so the jobs controller surfaces a wholly broken campaign
+        # instead of reporting SUCCEEDED, as it did when every shard failed on a
+        # missing environment variable.
+        logger.error("No shard completed - failing the job")
+        sys.exit(1)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--campaign", required=True, help="s3://bucket/campaign")
+    ap.add_argument("--parquet_uri", default="",
+                    help="Parquet output prefix (default: the campaign prefix)")
+    ap.add_argument("--model", default="PhaseNet")
+    ap.add_argument("--weight", default="jma_wc")
+    ap.add_argument("--components", default="ZNE12")
+    ap.add_argument("--p_threshold", default=0.2, type=float)
+    ap.add_argument("--s_threshold", default=0.2, type=float)
+    ap.add_argument("--data_queue_size", default=5, type=int)
+    ap.add_argument("--pick_queue_size", default=5, type=int)
+    ap.add_argument("--procs", default=1, type=int,
+                    help="Worker loops per node. Match to vCPUs, allowing for the "
+                         "picker's own threads.")
+    ap.add_argument("--lease-hours", default=6.0, type=float,
+                    help="A claim older than this with no manifest is reclaimable. "
+                         "Set above the longest expected shard runtime.")
+    ap.add_argument("--max-shards", default=0, type=int, help="Stop after N (0 = drain)")
+    ap.add_argument("--max-failures", default=0, type=int, help="Stop after N failures")
+    ap.add_argument("--profile", action="store_true",
+                    help="Report a per-stage timing breakdown after each shard: "
+                         "S3 list/head/get, mSEED parse, inference, both amplitude "
+                         "passes, and Parquet encode/put. Use --procs 1, since "
+                         "contention between worker loops distorts the attribution.")
+    ap.add_argument("--debug", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.procs <= 1:
+        loop(args, 0)
+        return
+    procs = [mp.Process(target=loop, args=(args, i)) for i in range(args.procs)]
+    for p in procs:
+        p.start()
+    try:
+        for p in procs:
+            p.join()
+    except KeyboardInterrupt:
+        for p in procs:
+            p.terminate()
+    # Any worker loop failing outright fails the node, for the same reason.
+    if any(p.exitcode not in (0, None) for p in procs):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sb_catalog/src/worker.py
+++ b/sb_catalog/src/worker.py
@@ -34,6 +34,7 @@ import sys
 import threading
 import time
 import uuid
+from typing import Optional
 
 import pandas as pd
 
@@ -51,9 +52,11 @@ class S3StateAdapter:
     is not part of a v3 picking campaign.
     """
 
-    def __init__(self, state: S3CampaignState, stations: pd.DataFrame):
+    def __init__(self, state: S3CampaignState, stations: pd.DataFrame,
+                 done: Optional[set] = None):
         self.state = state
         self._stations = stations
+        self.done = done or set()
         self.picks_record: list[dict] = []
         self.db_uri = state.root          # provenance strings expect these
         self.database = None
@@ -65,14 +68,20 @@ class S3StateAdapter:
         return self.state.get_stations(extent=extent, network=network)
 
     def get_picks_record(self, station, day, channel, key: dict = {}):
-        """Always None: resume is per shard in v3, not per channel-day.
+        """Whether this station-day-channel is already done, from the shard's
+        checkpointed progress.
 
-        A shard only runs when it has no manifest, and a manifest is only written
-        after its Parquet is durable, so nothing inside a running shard has been
-        committed. Answering None avoids ~800 S3 HEAD requests per shard to learn
-        something the queue already knows.
+        Answered from a set loaded once when the shard was claimed, so this
+        costs nothing per call - the alternative would be ~800 S3 HEADs per
+        shard. An empty set (a shard starting fresh) makes every answer None and
+        the whole shard runs, which is the common case.
+
+        This is what makes a preemption cheap: without it a resumed shard redoes
+        every station-day from the beginning, about twelve hours at the default
+        grouping.
         """
-        return None
+        entry = (station, day.year, int(day.strftime("%j")), channel)
+        return {"_id": entry} if entry in self.done else None
 
     def write_run_data(self, **kwargs) -> str:
         run_id = str(uuid.uuid4())
@@ -127,7 +136,17 @@ def _run_shard(shard: dict, args, state: S3CampaignState, stations: pd.DataFrame
     from .s3_helper import S3DataSource
     from .utils import parse_year_day
 
-    db = S3StateAdapter(state, stations)
+    done = state.read_progress(shard["shard_id"])
+    if done:
+        logger.info(
+            f"Resuming {shard['shard_id']}: {len(done)} station-day-channels "
+            f"already written, skipping them"
+        )
+    db = S3StateAdapter(state, stations, done=done)
+
+    def _checkpoint(records: list[dict]) -> None:
+        # Called only after the Parquet flush covering these records returned.
+        state.write_progress(shard["shard_id"], records)
     # S3DataSource wants dates, not the "%Y.%j" strings the queue carries, and
     # treats `end` as exclusive - the planner writes it that way.
     s3 = S3DataSource(
@@ -148,6 +167,8 @@ def _run_shard(shard: dict, args, state: S3CampaignState, stations: pd.DataFrame
         pick_queue_size=args.pick_queue_size,
         extent=None,
         classifier=False,          # the classifier is out for 2026
+        checkpoint_every=args.checkpoint_every,
+        on_checkpoint=_checkpoint,
         parquet_uri=args.parquet_uri or state.uri(),
         # One Parquet object per shard. Anything less specific collides inside a
         # (network, year, month) partition when a node runs many shards.
@@ -302,6 +323,12 @@ def main(argv=None):
                          "Set above the longest expected shard runtime.")
     ap.add_argument("--max-shards", default=0, type=int, help="Stop after N (0 = drain)")
     ap.add_argument("--max-failures", default=0, type=int, help="Stop after N failures")
+    ap.add_argument("--checkpoint-every", default=40, type=int,
+                    help="Flush Parquet and record progress every N "
+                         "station-day-channels. Bounds what a Spot preemption "
+                         "costs: at the default 40 stations x 20 days a shard is "
+                         "~12 h, so without this a preemption discards all of "
+                         "it. 0 disables checkpointing.")
     ap.add_argument("--profile", action="store_true",
                     help="Report a per-stage timing breakdown after each shard: "
                          "S3 list/head/get, mSEED parse, inference, both amplitude "

--- a/skypilot/campaign.yaml
+++ b/skypilot/campaign.yaml
@@ -1,0 +1,75 @@
+# QuakeScope v3 picking campaign on SkyPilot.
+#
+# Launch with `sky jobs launch`, NOT `sky launch`. A plain cluster with
+# use_spot does not come back after a preemption - only managed jobs are
+# recovered by the jobs controller. That recovery is the whole reason this
+# is safe to run on Spot.
+#
+#   sky jobs launch -n qs-scedc skypilot/campaign.yaml \
+#       --env CAMPAIGN=s3://quakescope-picks-2026/scedc \
+#       --env WEIGHT=jma_wc
+#
+# The queue must already exist - plan it first with shard_planner. Workers are
+# stateless and idempotent: scale NUM_NODES freely, and relaunch after a
+# preemption without cleaning anything up.
+
+name: quakescope-pick
+
+resources:
+  infra: aws/us-west-2
+  cpus: 32+
+  memory: 64+
+  disk_size: 200
+  # Run inside the image GitHub Actions already builds. It carries torch,
+  # seisbench, pyarrow and the model weights, so there is nothing to install at
+  # job start. That matters more than it looks: `setup` re-runs on every Spot
+  # recovery, so a pixi install there is paid again at each preemption.
+  # PIN THE SHORT-SHA TAG for a campaign - :latest can change mid-run.
+  image_id: docker:ghcr.io/seisscoped/quakescope:latest
+  # SPOT ONLY. An on-demand fallback here is silently ~3x the price: during the
+  # smoke test SkyPilot quietly satisfied one job on-demand and nothing in the
+  # logs said so - it was only visible in the EC2 console's InstanceLifecycle.
+  # A campaign that must be on Spot should queue when capacity is short, not
+  # spend its way through the shortage.
+  use_spot: true
+
+num_nodes: 4
+
+envs:
+  # Read at import by s3_helper. Empty is correct for campaigns on the
+  # public SCEDC/NCEDC buckets; set both for the EarthScope archive.
+  EARTHSCOPE_S3_ACCESS_POINT: ""
+  ES_OAUTH2__REFRESH_TOKEN: ""
+  CAMPAIGN: ""          # s3://bucket/campaign  (required)
+  WEIGHT: jma_wc
+  MODEL: PhaseNet
+  PROCS: "8"            # worker loops per node; the picker threads inside each
+  LEASE_HOURS: "6"
+  P_THRESHOLD: "0.2"
+  S_THRESHOLD: "0.2"
+
+# No workdir and no setup: the code is in the image at /code/src, pinned with it.
+# To test a branch before it is merged and built, add a workdir block and run
+# `python -m sb_catalog.src.worker` from ~/sky_workdir instead - the image still
+# supplies the environment, so nothing is installed either way.
+
+setup: |
+  python -c "import seisbench, pyarrow, torch; print('image ready:', seisbench.__version__)"
+
+run: |
+  cd /code
+  if [ -z "$CAMPAIGN" ]; then echo "CAMPAIGN is required"; exit 2; fi
+
+  echo "node ${SKYPILOT_NODE_RANK}/${SKYPILOT_NUM_NODES} -> ${CAMPAIGN}"
+
+  # Every node runs the same command. Which shards it gets is decided by the
+  # claim protocol in S3, not by rank, so a node that dies takes nothing with it
+  # and a node that joins late is immediately useful.
+  python -m src.worker \
+    --campaign "${CAMPAIGN}" \
+    --model "${MODEL}" \
+    --weight "${WEIGHT}" \
+    --procs "${PROCS}" \
+    --lease-hours "${LEASE_HOURS}" \
+    --p_threshold "${P_THRESHOLD}" \
+    --s_threshold "${S_THRESHOLD}"

--- a/skypilot/plan.yaml
+++ b/skypilot/plan.yaml
@@ -1,0 +1,45 @@
+# Plan a campaign's work queue. Cheap, short-lived, on-demand - this writes
+# shards.jsonl and exits, and must finish before any worker starts.
+#
+#   sky launch -c qs-plan skypilot/plan.yaml --down \
+#       --env CAMPAIGN=s3://quakescope-picks-2026/scedc \
+#       --env START=2019.001 --env END=2019.365 --env NETWORK=CI \
+#       --env STATIONS=s3://quakescope-picks-2026/stations.parquet
+
+name: quakescope-plan
+
+resources:
+  infra: aws/us-west-2
+  cpus: 2+
+  memory: 8+
+  use_spot: false        # minutes of work; not worth a preemption
+
+envs:
+  # Read at import by s3_helper. Empty is correct for campaigns on the
+  # public SCEDC/NCEDC buckets; set both for the EarthScope archive.
+  EARTHSCOPE_S3_ACCESS_POINT: ""
+  ES_OAUTH2__REFRESH_TOKEN: ""
+  CAMPAIGN: ""
+  START: ""
+  END: ""
+  NETWORK: ""
+  EXTENT: ""
+  STATIONS: ""
+
+workdir:
+  url: https://github.com/SeisSCOPED/QuakeScope.git
+  ref: main
+
+setup: |
+  curl -fsSL https://pixi.sh/install.sh | sh
+  export PATH="$HOME/.pixi/bin:$PATH"
+  cd ~/sky_workdir && pixi install --environment cloud
+
+run: |
+  export PATH="$HOME/.pixi/bin:$PATH"
+  cd ~/sky_workdir
+  ARGS="--campaign ${CAMPAIGN} --start ${START} --end ${END}"
+  [ -n "${NETWORK}" ]  && ARGS="${ARGS} --network ${NETWORK}"
+  [ -n "${EXTENT}" ]   && ARGS="${ARGS} --extent ${EXTENT}"
+  [ -n "${STATIONS}" ] && ARGS="${ARGS} --stations ${STATIONS}"
+  pixi run -e cloud python -m sb_catalog.src.shard_planner ${ARGS}

--- a/skypilot/sky-config.yaml
+++ b/skypilot/sky-config.yaml
@@ -1,0 +1,19 @@
+# Copy to ~/.sky/config.yaml. Controller settings are NOT read from a task or
+# project YAML - SkyPilot only honours them here.
+#
+# The reason this file exists: `sky down --all` does not terminate the managed
+# jobs controller. It reports success and leaves an on-demand instance running,
+# which on a Spot campaign is the most expensive thing to forget. Observed
+# directly - after cancelling every job and running `sky down --all`, an
+# on-demand m6i.xlarge controller was still up at $0.192/hour.
+
+jobs:
+  controller:
+    autostop:
+      # Terminate, do not stop. `down: false` (the default) leaves a stopped
+      # instance that still bills its EBS volume and still shows up as a leak.
+      down: true
+      idle_minutes: 15
+      # Wait for both jobs and SSH sessions to be idle, so a controller is never
+      # torn down while a campaign is still submitting to it.
+      wait_for: jobs_and_ssh

--- a/tests/test_checkpoint_resume.py
+++ b/tests/test_checkpoint_resume.py
@@ -1,0 +1,134 @@
+"""A preempted shard must resume, not restart.
+
+Without checkpointing a Spot interruption twelve hours into a shard discards
+twelve hours of work, because picks are buffered until the job ends. These
+checks cover the three things that has to get right: progress is only recorded
+after the data is durable, a resumed shard skips what is already written, and
+the ordering cannot be inverted.
+"""
+
+import datetime
+import json
+import os
+import sys
+import tempfile
+import threading
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import obspy
+import seisbench.util as sbu
+from botocore.exceptions import ClientError
+
+from sb_catalog.src.parquet_writer import ParquetPickWriter
+from sb_catalog.src.s3_state import S3CampaignState
+from sb_catalog.src.worker import S3StateAdapter
+
+
+class FakeS3:
+    """Enough S3 for the state store, with real conditional-write semantics."""
+
+    def __init__(self):
+        self.obj, self.lock = {}, threading.Lock()
+
+    def put_object(self, Bucket, Key, Body, ContentType=None, IfNoneMatch=None):
+        with self.lock:
+            if IfNoneMatch is not None and Key in self.obj:
+                raise ClientError({"Error": {"Code": "PreconditionFailed"}}, "PutObject")
+            self.obj[Key] = Body if isinstance(Body, bytes) else Body.encode()
+            return {}
+
+    def get_object(self, Bucket, Key):
+        import io
+        with self.lock:
+            if Key not in self.obj:
+                raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+            return {"Body": io.BytesIO(self.obj[Key])}
+
+    def head_object(self, Bucket, Key):
+        with self.lock:
+            if Key not in self.obj:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            return {}
+
+    def delete_object(self, Bucket, Key):
+        with self.lock:
+            self.obj.pop(Key, None)
+            return {}
+
+    def get_paginator(self, name):
+        outer = self
+
+        class P:
+            def paginate(self, Bucket, Prefix):
+                with outer.lock:
+                    keys = [k for k in outer.obj if k.startswith(Prefix)]
+                yield {"Contents": [{"Key": k} for k in keys]}
+
+        return P()
+
+
+def _pick(t):
+    return sbu.Pick(trace_id="CI.CLC.", start_time=t, end_time=t + 1,
+                    peak_time=t + 0.5, peak_value=0.9, phase="P")
+
+
+def test_checkpoint_and_resume():
+    fake = FakeS3()
+    state = S3CampaignState("s3://bkt/camp", client=fake)
+    shard_id = "2019187-2019190-abc123def456"
+    root = tempfile.mkdtemp()
+
+    # --- a shard runs three station-days, then is preempted -----------------
+    writer = ParquetPickWriter(root=root, run_id="r1", job_id=shard_id)
+    t = obspy.UTCDateTime("2019-07-06T00:00:10")
+    for doy, day in enumerate([datetime.date(2019, 7, 6),
+                               datetime.date(2019, 7, 7),
+                               datetime.date(2019, 7, 8)]):
+        writer.add([_pick(t)], [1.0], [2.0], [], "CI.CLC.", day, "HH")
+
+    records = writer.checkpoint()
+    state.write_progress(shard_id, records)
+    assert len(records) == 3
+    print(f"PASS  checkpoint flushed and recorded {len(records)} station-days")
+
+    # Durability is the point: the Parquet must exist before progress claims it.
+    written = [f for f in os.listdir(os.path.join(root, "picks")) or []]
+    assert written, "checkpoint recorded progress without writing Parquet"
+    print("PASS  Parquet written before progress was recorded")
+
+    # --- a new worker picks the shard up ------------------------------------
+    resumed = state.read_progress(shard_id)
+    assert resumed == {("CI.CLC.", 2019, 187, "HH"),
+                       ("CI.CLC.", 2019, 188, "HH"),
+                       ("CI.CLC.", 2019, 189, "HH")}
+    print(f"PASS  resume loaded {len(resumed)} completed station-day-channels")
+
+    adapter = S3StateAdapter(state, stations=None, done=resumed)
+    already = adapter.get_picks_record("CI.CLC.", datetime.date(2019, 7, 6), "HH")
+    fresh = adapter.get_picks_record("CI.CLC.", datetime.date(2019, 7, 9), "HH")
+    assert already is not None, "resumed shard would redo a completed station-day"
+    assert fresh is None, "resumed shard would skip work it never did"
+    print("PASS  completed station-days skipped, unfinished ones still run")
+
+    # A shard that never checkpointed starts clean rather than erroring.
+    assert state.read_progress("never-ran-0000") == set()
+    print("PASS  a shard with no progress starts from the beginning")
+
+    # --- the ordering trap ---------------------------------------------------
+    # Progress must never be recorded for picks that were not written. The
+    # writer returns records only from checkpoint(), which flushes first, so
+    # there is no path that reports unwritten work.
+    w2 = ParquetPickWriter(root=tempfile.mkdtemp(), run_id="r2", job_id="j2")
+    w2.add([_pick(t)], [1.0], [2.0], [], "CI.TOW2.", datetime.date(2019, 7, 6), "HH")
+    assert w2.pending_records == 1
+    before = json.loads(fake.obj.get(
+        state._key("progress", "j2.json"), b"null") or b"null")
+    assert before is None, "progress existed before any checkpoint"
+    print("PASS  buffered-but-unflushed work is never recorded as progress")
+
+    print("\nall checkpoint/resume checks passed")
+
+
+if __name__ == "__main__":
+    test_checkpoint_and_resume()

--- a/tests/test_claim_protocol.py
+++ b/tests/test_claim_protocol.py
@@ -1,0 +1,148 @@
+"""Exercise the claim protocol
+
+Run: pixi run -e cloud python tests/test_claim_protocol.py
+
+Original docstring against a fake S3 with real IfNoneMatch semantics,
+including the concurrent race and the Spot-preemption reclaim path."""
+import datetime, json, os, sys, threading
+from botocore.exceptions import ClientError
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from sb_catalog.src.s3_state import S3CampaignState
+
+
+class FakeS3:
+    """Minimal S3 with atomic conditional PUT, guarded by a lock the way S3's
+    strong consistency guards a real bucket."""
+    def __init__(self):
+        self.obj, self.lock = {}, threading.Lock()
+        self.conditional_puts = 0
+        self.rejected = 0
+
+    def put_object(self, Bucket, Key, Body, ContentType=None, IfNoneMatch=None):
+        with self.lock:
+            if IfNoneMatch is not None:
+                self.conditional_puts += 1
+                if IfNoneMatch != "*":
+                    raise ValueError("only '*' supported")
+                if Key in self.obj:
+                    self.rejected += 1
+                    raise ClientError({"Error": {"Code": "PreconditionFailed"}}, "PutObject")
+            self.obj[Key] = Body if isinstance(Body, bytes) else Body.encode()
+            return {}
+
+    def get_object(self, Bucket, Key):
+        with self.lock:
+            if Key not in self.obj:
+                raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+            import io
+            return {"Body": io.BytesIO(self.obj[Key])}
+
+    def head_object(self, Bucket, Key):
+        with self.lock:
+            if Key not in self.obj:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            return {}
+
+    def delete_object(self, Bucket, Key):
+        with self.lock:
+            self.obj.pop(Key, None)
+            return {}
+
+    def get_paginator(self, name):
+        outer = self
+        class P:
+            def paginate(self, Bucket, Prefix):
+                with outer.lock:
+                    keys = [k for k in outer.obj if k.startswith(Prefix)]
+                yield {"Contents": [{"Key": k} for k in keys]}
+        return P()
+
+
+def test_claim_protocol():
+    """Claiming must be atomic, leases must expire, completed work must never
+    re-run. Spot recovery depends on all three."""
+    fake = FakeS3()
+    st = S3CampaignState("s3://bkt/campaign", client=fake)
+
+    # ---- 1. immutable queue -----------------------------------------------------
+    shards = [{"shard_id": f"s{i:04d}", "stations": ["CI.CLC."], "start": "2019.001",
+               "end": "2019.020"} for i in range(50)]
+    st.write_shards(shards)
+    try:
+        st.write_shards(shards); print("FAIL: queue was overwritten")
+    except FileExistsError:
+        print("PASS  queue is immutable once written")
+    assert len(st.read_shards()) == 50
+
+    # ---- 2. two workers race for every shard ------------------------------------
+    winners, lock = {}, threading.Lock()
+    def race(worker):
+        s = S3CampaignState("s3://bkt/campaign", client=fake)
+        s.worker_id = worker
+        for sh in shards:
+            if s.claim(sh["shard_id"]):
+                with lock:
+                    winners.setdefault(sh["shard_id"], []).append(worker)
+
+    ts = [threading.Thread(target=race, args=(f"w{i}",)) for i in range(8)]
+    [t.start() for t in ts]; [t.join() for t in ts]
+    dupes = {k: v for k, v in winners.items() if len(v) > 1}
+    print(f"PASS  8 workers x 50 shards -> {len(winners)} claimed, "
+          f"{len(dupes)} double-claimed" if not dupes else f"FAIL: double-claimed {dupes}")
+    print(f"      {fake.conditional_puts} conditional PUTs, {fake.rejected} rejected by S3")
+    assert len(winners) == 50 and not dupes
+
+    # ---- 3. a live claim is not stealable ---------------------------------------
+    other = S3CampaignState("s3://bkt/campaign", client=fake); other.worker_id = "intruder"
+    print("PASS  live claim is not stealable" if not other.claim("s0000")
+          else "FAIL: stole a live claim")
+
+    # ---- 4. Spot preemption: stale claim, no manifest -> reclaimable -------------
+    key = st._key("claims", "s0007.json")
+    stale = json.loads(fake.obj[key])
+    stale["claimed"] = (datetime.datetime.now(datetime.timezone.utc)
+                        - datetime.timedelta(hours=9)).isoformat()
+    fake.obj[key] = json.dumps(stale).encode()
+    print("PASS  stale claim reclaimed after preemption" if other.claim("s0007")
+          else "FAIL: stale claim not reclaimed")
+
+    # ---- 5. stale claim WITH a manifest is finished work, not reclaimable --------
+    st.complete("s0008", {"picks": 1234})
+    key = st._key("claims", "s0008.json")
+    d = json.loads(fake.obj[key])
+    d["claimed"] = (datetime.datetime.now(datetime.timezone.utc)
+                    - datetime.timedelta(hours=9)).isoformat()
+    fake.obj[key] = json.dumps(d).encode()
+    print("PASS  completed shard never re-run" if not other.claim("s0008")
+          else "FAIL: would re-run completed work")
+
+    # ---- 6. release returns work immediately ------------------------------------
+    st.release("s0009")
+    print("PASS  release requeues at once" if other.claim("s0009")
+          else "FAIL: release did not requeue")
+
+    # ---- 7. resume view ---------------------------------------------------------
+    for i in range(20):
+        st.complete(f"s{i:04d}", {"picks": i})
+    p = st.progress()
+    print(f"PASS  progress: {p}")
+    # s0008 was already completed above, so 20 distinct, not 21
+    assert p["total"] == 50 and p["complete"] == 20 and p["remaining"] == 30
+    assert len(st.completed_ids()) == 20
+
+    # ---- 8. endpoint without conditional writes fails loudly --------------------
+    class NoCond(FakeS3):
+        def put_object(self, Bucket, Key, Body, ContentType=None, IfNoneMatch=None):
+            if IfNoneMatch is not None:
+                raise ClientError({"Error": {"Code": "NotImplemented"}}, "PutObject")
+            return super().put_object(Bucket, Key, Body, ContentType)
+    try:
+        S3CampaignState("s3://b/c", client=NoCond()).claim("x")
+        print("FAIL: silently raced on a non-conditional endpoint")
+    except RuntimeError as e:
+        print(f"PASS  refuses to race: {str(e)[:58]}...")
+    print("\nall claim-protocol checks passed")
+
+
+if __name__ == "__main__":
+    test_claim_protocol()

--- a/tests/test_claim_protocol.py
+++ b/tests/test_claim_protocol.py
@@ -18,7 +18,8 @@ class FakeS3:
         self.conditional_puts = 0
         self.rejected = 0
 
-    def put_object(self, Bucket, Key, Body, ContentType=None, IfNoneMatch=None):
+    def put_object(self, Bucket, Key, Body, ContentType=None, IfNoneMatch=None,
+                   IfMatch=None):
         with self.lock:
             if IfNoneMatch is not None:
                 self.conditional_puts += 1
@@ -27,15 +28,27 @@ class FakeS3:
                 if Key in self.obj:
                     self.rejected += 1
                     raise ClientError({"Error": {"Code": "PreconditionFailed"}}, "PutObject")
+            if IfMatch is not None:
+                # Compare-and-swap: succeed only if the object is unchanged.
+                self.conditional_puts += 1
+                if self._etag(Key) != IfMatch:
+                    self.rejected += 1
+                    raise ClientError({"Error": {"Code": "PreconditionFailed"}}, "PutObject")
             self.obj[Key] = Body if isinstance(Body, bytes) else Body.encode()
             return {}
+
+    def _etag(self, Key):
+        import hashlib
+        if Key not in self.obj:
+            return None
+        return '"%s"' % hashlib.md5(self.obj[Key]).hexdigest()
 
     def get_object(self, Bucket, Key):
         with self.lock:
             if Key not in self.obj:
                 raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
             import io
-            return {"Body": io.BytesIO(self.obj[Key])}
+            return {"Body": io.BytesIO(self.obj[Key]), "ETag": self._etag(Key)}
 
     def head_object(self, Bucket, Key):
         with self.lock:
@@ -105,6 +118,29 @@ def test_claim_protocol():
     fake.obj[key] = json.dumps(stale).encode()
     print("PASS  stale claim reclaimed after preemption" if other.claim("s0007")
           else "FAIL: stale claim not reclaimed")
+
+    # ---- 4b. many workers see the same stale claim at once ----------------------
+    # Copilot caught this: the takeover used to be an unconditional PUT, so every
+    # worker that observed staleness "won" and they all ran the same shard.
+    key = st._key("claims", "s0010.json")
+    d = json.loads(fake.obj[key])
+    d["claimed"] = (datetime.datetime.now(datetime.timezone.utc)
+                    - datetime.timedelta(hours=9)).isoformat()
+    fake.obj[key] = json.dumps(d).encode()
+
+    winners = []
+    def steal(w):
+        s = S3CampaignState("s3://bkt/campaign", client=fake)
+        s.worker_id = f"thief{w}"
+        if s.claim("s0010"):
+            with lock:
+                winners.append(w)
+    ts = [threading.Thread(target=steal, args=(i,)) for i in range(8)]
+    [t.start() for t in ts]; [t.join() for t in ts]
+    print(f"PASS  8 workers raced one stale claim -> {len(winners)} winner(s)"
+          if len(winners) == 1 else
+          f"FAIL: {len(winners)} workers all took the same stale shard")
+    assert len(winners) == 1
 
     # ---- 5. stale claim WITH a manifest is finished work, not reclaimable --------
     st.complete("s0008", {"picks": 1234})


### PR DESCRIPTION
Replaces AWS Batch + Fargate Spot + DocumentDB with **SkyPilot managed jobs pulling from a work queue on S3**, then fixes what actually running it on AWS revealed.

Third in a stack: **#26 → #28 (amplitude) → #29 (monitoring) → this**. Diff against #29 is **18 files, +6.1k** — mostly new modules and docs.

## The execution model

| module | role |
|---|---|
| `s3_state.py` | Campaign state on S3, replacing DocumentDB. Atomic shard claims via S3 conditional write (`IfNoneMatch: "*"`). |
| `shard_planner.py` | 2025's grouping — 40 stations × 20 days — written once as an immutable `shards.jsonl` instead of 64,240 `submit_job` calls. |
| `worker.py` | Claim → pick → flush Parquet → write manifest, in that order. |
| `skypilot/*.yaml` | Templates. Spot only. |

Launched with `sky jobs launch`, **not** `sky launch`: a plain cluster with `use_spot` gets Spot instances but no recovery — only managed jobs are relaunched. Spot survival has three layers: atomic claims, a SIGTERM handler that releases the in-flight claim on preemption's ~2 min warning, and a lease expiry for hard kills. A manifest is written only after Parquet is durable, so it never exists for lost picks.

## Seven bugs found by running it, not by review

Five of the seven fail **silently**:

| bug | consequence |
|---|---|
| Inclusive end vs `np.arange` | **Silent** — dropped the last day of every shard, ~5% of the campaign |
| Parquet key defaulted to `HOSTNAME` | **Silent** — every shard on a node overwrote the last. Safe under Batch only because the Batch job id happened to be unique |
| Manifest namespace collision | **Silent** — resume counted the writer's manifest as a finished shard |
| Unbounded EarthScope credential retry | **Silent** — infinite hang holding a claim; would consume the budget producing nothing |
| Exit 0 after failing every shard | **Silent** — a wholly broken campaign reported SUCCEEDED |
| `EARTHSCOPE_S3_ACCESS_POINT` required at import | Crash on SCEDC-only campaigns |
| Strings passed where dates required | Crash on first shard |

Also: `pyarrow` was missing from the Dockerfile, so **the published image could not run a Parquet job at all**.

## Measurement

`worker --profile` instruments the real code path. On a real shard:

| stage | share |
|---|--:|
| amp.wood_anderson | 47% |
| model.classify | 45% |
| amp.raw | 4% |
| all S3 + parsing | **<4%** |
| parquet encode + put | **0.1%** |

So the workload is **CPU-bound** — cross-region reads are not a cost problem — and **writing Parquet is free**. `docs/rerun_2026/16_skypilot_vs_fargate.md` has the platform comparison, cost model, and how to read the output (DocumentDB, partition-pruned Parquet, and a LIST-free path via the manifests).

## Terminating when the job is done

Managed jobs terminate their **worker** cluster automatically. The **jobs controller does not stop itself**, and `sky down --all` does not terminate it either — it reports success and leaves an on-demand instance running. Observed directly: after cancelling every job and running `sky down --all`, an on-demand `m6i.xlarge` was still up at $0.192/hour.

`skypilot/sky-config.yaml` fixes it once, before launching:

```yaml
jobs:
  controller:
    autostop:
      down: true            # terminate; the default only *stops* it
      idle_minutes: 15
      wait_for: jobs_and_ssh
```

Controller settings are read **only** from `~/.sky/config.yaml`; a task or project YAML is ignored. Validated against the SkyPilot 0.13 schema.

## Checkpointing

Picks are buffered until a job ends, so a preemption discarded the whole in-flight shard — about **twelve hours** at the 40×20 grouping. The worker now flushes and records progress every `--checkpoint-every` station-day-channels (default 40); a resumed shard skips what is already written.

The ordering is the part that must be right: `checkpoint()` flushes every buffered partition and *then* returns the records it covered, and progress is written only from that return value. Recording first would let a resume skip station-days whose picks were never stored.

`tests/test_checkpoint_resume.py` covers all three invariants.

## Verified

- 8 concurrent workers × 50 shards → **50 claims, 0 double-claims**; confirmed against **real S3**, which returns `PreconditionFailed`/412 as the protocol assumes.
- Two shards end-to-end on a real **Spot** instance → 15,064 picks in two distinctly-named Parquet objects, `remaining: 0`.
- 46,714 stations × 1096 days → 64,240 shards, no station-day dropped.

## Known gaps

- **Association still needs a database** — a v3 campaign is picking only, which matches the 2026 plan.
- **No true Fargate head-to-head yet**: the published image is built from `main`, so it still crashes on import. `quakescope_v3_bench` is registered and `python -m src.picker work` is wired; both run the same worker once this merges and Actions rebuilds.
- **Cost Explorer is blocked by an org SCP**, so the 2025 actuals could not be recovered — the "match or beat" baseline needs a billing-console export.
- **Two levers unmeasured** that together swing campaign cost ~4×: processes per vCPU, and one-band-per-station (2.83× on SCEDC).

Version bumped to **3.0.0**; tag on `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
