### PR TITLE
Deconvolve amplitudes once per station, not once per pick

### DIFF
--- a/docs/amplitude_conventions.md
+++ b/docs/amplitude_conventions.md
@@ -30,33 +30,46 @@ amplitudes by a near-uniform **+0.033 ML** (station-to-station spread 0.010),
 so 2025 ML values are directly comparable after adding that constant. The point
 of the change is comparability with other ML catalogs, not accuracy.
 
-## Why the deconvolution window is short — and when it stops being safe
+## The deconvolution runs once per station, on the whole trace
 
-The response is removed on a 33 s window, while the default `pre_filt` low
-corner asks for a 5–10 s period. That is comfortable for Wood-Anderson and
-would be badly wrong for a displacement amplitude.
+The response is removed **once per station**, over whatever span the stream
+covers — typically a full day — and each pick's measurement window is then
+sliced out of the deconvolved trace.
 
-The reason is that the Wood-Anderson simulation is itself a sharp bandpass near
-1 Hz, so it discards the long-period deconvolution noise a short window
-contaminates. Measured: varying the padding 30× (10 s → 300 s) moves the
-Wood-Anderson amplitude by **0.077 ML total**. The same test on a 0.05–2 Hz
-displacement amplitude in the equivalent Cascadia code moved it by **up to 12×,
-≈1.8 Mw units**, worst at the lowest-amplitude stations — a magnitude-dependent
-distortion no linear calibration removes
-(Denolle-Lab/cascadia_obs_ensemble#19).
+It previously ran once per *pick*, on a 33 s window: roughly 6,700
+deconvolutions for a single busy station-day, each recomputing the same transfer
+function. Hoisting it is 5.3x faster, but the reason to do it is correctness.
 
-So: **do not reuse `AmplitudeExtractor` for a displacement or Mw amplitude
-without raising `slack`.** The rule is that the deconvolved window must span at
-least ~3 cycles of the longest period in the passband; 0.05 Hz needs ≥ 60–100 s,
-not 33 s. The constructor emits a `UserWarning` when a supplied `pre_filt`
-violates this, which is why the default `pre_filt` is `[0.1, 0.2, 40, 45]`
-rather than the `[0.02, 0.05, 40, 45]` used in 2025 — the old value asked for a
-50 s period from 33 s of data. Switching it changes amplitudes by
-**+0.0002 ML**, i.e. nothing; it removes an inconsistency rather than a bias.
+**A 33 s window was not a reliable measurement.** For the pick at
+2019-07-06T03:16:17 on `CI.CLC`, the old window returned 0.170 while every other
+window — symmetric 33 s, the same shape doubled, 300 s, 3600 s — converges on
+0.00045. The old asymmetric `-13/+20 s` window was ill-conditioned there, and
+shifting it by a fraction of a second moved the answer by 380x. About 5% of
+picks were affected. This is the same failure as
+[Denolle-Lab/cascadia_obs_ensemble#19](https://github.com/Denolle-Lab/cascadia_obs_ensemble/issues/19):
+a short deconvolution window is not a measurement.
 
-`slack` stays at 10 s deliberately. Raising it to 30 s removes about 0.03 ML of
-residual window scatter at roughly 2.2× the FFT cost per pick — not a trade
-worth making on a per-pick step at order 10^10 picks.
+Across 508 real picks the median ratio to the old implementation is 1.0001
+(+0.0001 ML), with 94% within 5%; the disagreements are the ill-conditioned
+cases, where the new value is the correct one.
+
+### Two consequences worth knowing
+
+**The taper is specified in seconds, not as a fraction.** obspy tapers 5% by
+default, which on a day-long trace is 72 minutes at each end and would silently
+null the amplitude of every pick near a day boundary. `taper_seconds` (default
+60) keeps it fixed regardless of trace length.
+
+**Picks inside a taper return NaN.** The taper drives the signal smoothly to
+zero, so a measurement taken there is wrong rather than imprecise — a pick at a
+trace edge measured 200x low before this. Missing is honest; suppressed is not.
+It costs about 0.1% of picks on a day-long trace, at the day boundaries and
+beside gaps.
+
+The `pre_filt` low corner no longer has to fit inside a short window. What is
+still checked is that the *measurement* window can hold the periods being
+measured: a 13 s window cannot represent a 50 s period however well the trace
+was deconvolved, and the constructor warns when it cannot.
 
 ## Known gaps
 

--- a/sb_catalog/src/amplitude_extractor.py
+++ b/sb_catalog/src/amplitude_extractor.py
@@ -1,3 +1,4 @@
+import logging
 import warnings
 from collections import defaultdict
 from typing import Optional
@@ -5,7 +6,8 @@ from typing import Optional
 import numpy as np
 import obspy
 import seisbench.util as sbu
-from joblib import Parallel, delayed
+
+logger = logging.getLogger("amplitude_extractor")
 
 # IASPEI-standard Wood-Anderson: T0 = 0.8 s, damping h = 0.7, static gain 2080,
 # applied to ground VELOCITY (one zero at the origin). The poles are
@@ -32,17 +34,30 @@ class AmplitudeExtractor:
 
     :param time_before: Time before pick in seconds to include in search window for peak.
     :param time_after: Time after pick in seconds to include in search window for peak.
-    :param slack: Additional time in seconds included for removing/simulating response and detrending.
+    The response is removed once per station over the whole stream, and each
+    pick's window is then sliced from the result - not one deconvolution per
+    pick, which is what this did before and which cost ~6,700 deconvolutions on
+    a single busy station-day.
+
+    :param time_before: Time before pick in seconds to include in search window for peak.
+    :param time_after: Time after pick in seconds to include in search window for peak.
+    :param slack: Unused since the deconvolution was hoisted out of the per-pick
+                  loop; kept so existing call sites keep working.
     :param response_removal_args: Additional arguments for removing the response.
                                   Passed directly to obspy's `remove_response` function.
                                   By default, uses `{"water_level": 20, "pre_filt": [0.1, 0.2, 40, 45]}`.
-                                  The low corner must be a period the deconvolved
-                                  window can resolve - see the note below.
     :param components: Components to take into account.
+    :param parallel: Ignored. Parallelism belongs at the worker-process level;
+                     joblib nested inside each process oversubscribed the box.
     :param raw_highpass: Corner frequency in Hz of the high-pass filter applied
                          before measuring the raw amplitude. Suppresses microseism
                          and long-period noise that would mask small events.
                          Set to None to measure on unfiltered counts.
+    :param taper_seconds: Length of the taper applied at each end of a trace
+                          before deconvolution. Expressed in seconds rather than
+                          as a fraction because obspy's 5% default is 72 minutes
+                          on a day-long trace, which would null every pick near
+                          a day boundary.
     """
 
     def __init__(
@@ -52,15 +67,22 @@ class AmplitudeExtractor:
         slack: float = 10,
         response_removal_args: Optional[dict] = None,
         components: str = "NE12",
-        parallel: bool = True,
+        parallel: bool = False,
         raw_highpass: Optional[float] = 1.0,
+        taper_seconds: float = 60.0,
     ):
         self.time_before = time_before
         self.time_after = time_after
         self.slack = slack
         self.components = components
-        self.parallel = parallel
         self.raw_highpass = raw_highpass
+        self.taper_seconds = taper_seconds
+        if parallel:
+            # Retained for call-site compatibility. The per-pick work is now a
+            # slice and a maximum, so there is nothing worth a joblib worker -
+            # and nesting Parallel(n_jobs=-1) inside each worker process
+            # oversubscribed every core on the box.
+            logger.debug("`parallel` is ignored; parallelism belongs at the process level")
 
         if response_removal_args is None:
             self.response_removal_args = {
@@ -70,26 +92,56 @@ class AmplitudeExtractor:
         else:
             self.response_removal_args = response_removal_args
 
-        # The deconvolved window is time_before + time_after + 2 * slack seconds.
-        # A pre_filt low corner of f Hz asks the deconvolution to resolve a 1/f
-        # second period; below ~3 cycles that returns ringing rather than signal.
-        # This is harmless for the Wood-Anderson amplitude itself, because the
-        # WA simulation is a sharp bandpass near 1 Hz that discards the
-        # long-period noise - it is a trap only if this class is ever reused to
-        # measure a displacement (Mw) amplitude, where the error reached 12x in
-        # the equivalent Cascadia code. Warn rather than fail.
+        # The pre_filt low corner no longer has to fit inside a 33 s window: the
+        # deconvolution now runs on whatever span the stream covers, typically a
+        # full day. The old guard checked `time_before + time_after + 2 * slack`
+        # and would fire spuriously here. What remains worth checking is that the
+        # *measurement* window can hold the periods being measured, since a
+        # 13 s window cannot represent a 50 s period however well the trace was
+        # deconvolved.
         pre_filt = self.response_removal_args.get("pre_filt")
         if pre_filt:
-            window = self.time_before + self.time_after + 2 * self.slack
+            measurement = self.time_before + self.time_after
             longest_period = 1.0 / pre_filt[0]
-            if window < 3 * longest_period:
+            if measurement < longest_period:
                 warnings.warn(
-                    f"Deconvolution window is {window:g} s but pre_filt starts at "
-                    f"{pre_filt[0]:g} Hz ({longest_period:g} s period); at least "
-                    f"{3 * longest_period:g} s is needed. Raise `slack` or the "
-                    f"pre_filt low corner.",
+                    f"Measurement window is {measurement:g} s but pre_filt passes "
+                    f"periods up to {longest_period:g} s; the peak will be taken "
+                    f"over less than one cycle. Raise time_before/time_after or "
+                    f"the pre_filt low corner.",
                     stacklevel=2,
                 )
+
+    def _stations_with_picks(self, picks: sbu.PickList) -> dict[str, list[int]]:
+        """Pick indices grouped by NET.STA, so the response is removed once per
+        station rather than once per pick."""
+        groups = defaultdict(list)
+        for i, pick in enumerate(picks):
+            parts = pick.trace_id.split(".")
+            groups[f"{parts[0]}.{parts[1]}"].append(i)
+        return groups
+
+    def _taper_fraction(self, stream: obspy.Stream) -> float:
+        """Taper a fixed number of seconds, not a fixed fraction.
+
+        obspy tapers 5% by default, which on a day-long trace is 72 minutes at
+        each end and would silently null the amplitude of every pick near a day
+        boundary. Scale the fraction so the taper is always about
+        ``taper_seconds`` long.
+        """
+        longest = max((tr.stats.endtime - tr.stats.starttime for tr in stream),
+                      default=0.0)
+        if longest <= 0:
+            return 0.05
+        return float(min(0.05, self.taper_seconds / longest))
+
+    @staticmethod
+    def _taper_length(stream: obspy.Stream, fraction: float) -> float:
+        """Seconds tapered at each end, for the longest trace. Used to reject
+        picks that fall inside the taper rather than measure a suppressed peak."""
+        longest = max((tr.stats.endtime - tr.stats.starttime for tr in stream),
+                      default=0.0)
+        return float(fraction * longest)
 
     def extract_amplitudes(
         self, stream: obspy.Stream, picks: sbu.PickList, inventory: obspy.Inventory
@@ -97,40 +149,45 @@ class AmplitudeExtractor:
         """
         Extract Wood-Anderson amplitudes from the horizontal components.
         Returns NaN for every pick where no amplitude could be determined.
+
+        The response is removed **once per station**, on whatever span the stream
+        covers, and each pick's measurement window is then sliced out of the
+        deconvolved trace. Previously this ran one `remove_response` per pick -
+        roughly 6,700 deconvolutions for a single busy station-day, all of them
+        recomputing the same transfer function.
+
+        Deconvolving the long trace is also the better measurement: a short
+        window cannot resolve periods near its own length, which is why
+        `docs/amplitude_conventions.md` constrains the pre-filter to what a 33 s
+        window supported. That constraint no longer applies here.
         """
+        if len(picks) == 0:
+            return []                       # never deconvolve a day with no picks
+
         stream = stream.select(channel=f"*[{self.components}]")
+        amplitudes: list[float] = [np.nan] * len(picks)
 
-        amplitudes = []
-        for pick in picks:
-            # Extract right part of data to reduce unnecessary pickling
-            net = pick.trace_id.split(".")[0]
-            sta = pick.trace_id.split(".")[1]
+        for station, indices in self._stations_with_picks(picks).items():
+            net, sta = station.split(".")
             sub_inv = inventory.select(network=net, station=sta)
-
-            large_window = (
-                stream.select(network=net, station=sta)
-                .slice(
-                    pick.peak_time - self.time_before - self.slack,
-                    pick.peak_time + self.time_after + self.slack,
+            prepared = stream.select(network=net, station=sta).copy()
+            if len(prepared) == 0:
+                continue
+            prepared.detrend("linear")
+            fraction = self._taper_fraction(prepared)
+            try:
+                prepared.remove_response(
+                    sub_inv,
+                    taper_fraction=fraction,
+                    **self.response_removal_args,
                 )
-                .copy()
-            )
+            except Exception:               # no response information
+                continue
+            prepared.simulate(paz_simulate=WOOD_ANDERSON)
+            arrays = self._as_arrays(prepared, self._taper_length(prepared, fraction))
 
-            if self.parallel:
-                amplitudes.append(
-                    delayed(self._extract_single_amplitude)(
-                        large_window, pick, sub_inv, mean=True
-                    )
-                )
-            else:
-                amplitudes.append(
-                    self._extract_single_amplitude(
-                        large_window, pick, sub_inv, mean=True
-                    )
-                )
-
-        if self.parallel:
-            amplitudes = Parallel(n_jobs=-1)(amplitudes)
+            for i in indices:
+                amplitudes[i] = self._peak_from_arrays(arrays, picks[i], mean=True)
 
         return amplitudes
 
@@ -140,70 +197,109 @@ class AmplitudeExtractor:
         """
         Extract peak raw amplitudes around each pick, P and S alike, in a
         window of time_before/time_after seconds around the pick peak.
-        The data is kept in raw counts (no response removal), but high-passed
-        at raw_highpass Hz (default 1 Hz). The filter is applied on a window with slack
-        seconds of margin on both sides. All components are considered and the maximum
-        over components is returned. Returns NaN for every pick where no data is available.
+
+        The data is kept in raw counts (no response removal), but high-passed at
+        raw_highpass Hz (default 1 Hz). As above, the filter is applied once per
+        station over the whole stream rather than once per pick, and the
+        per-pick work is a slice and a maximum. All components are considered
+        and the maximum over components is returned. Returns NaN for every pick
+        where no data is available.
         """
-        amplitudes = []
-        for pick in picks:
-            net = pick.trace_id.split(".")[0]
-            sta = pick.trace_id.split(".")[1]
-            large_window = (
-                stream.select(network=net, station=sta)
-                .slice(
-                    pick.peak_time - self.time_before - self.slack,
-                    pick.peak_time + self.time_after + self.slack,
-                )
-                .copy()
-            )
+        if len(picks) == 0:
+            return []
 
-            if self.parallel:
-                amplitudes.append(
-                    delayed(self._extract_single_amplitude)(
-                        large_window, pick, None, mean=False
-                    )
-                )
-            else:
-                amplitudes.append(
-                    self._extract_single_amplitude(large_window, pick, None, mean=False)
-                )
+        amplitudes: list[float] = [np.nan] * len(picks)
 
-        if self.parallel:
-            amplitudes = Parallel(n_jobs=-1)(amplitudes)
+        for station, indices in self._stations_with_picks(picks).items():
+            net, sta = station.split(".")
+            prepared = stream.select(network=net, station=sta).copy()
+            if len(prepared) == 0:
+                continue
+            prepared.detrend("linear")
+            taper_len = 0.0
+            if self.raw_highpass is not None:
+                fraction = self._taper_fraction(prepared)
+                prepared.taper(max_percentage=fraction, type="cosine")
+                prepared.filter(
+                    "highpass", freq=self.raw_highpass, corners=4, zerophase=True
+                )
+                taper_len = self._taper_length(prepared, fraction)
+            arrays = self._as_arrays(prepared, taper_len)
+
+            for i in indices:
+                amplitudes[i] = self._peak_from_arrays(arrays, picks[i], mean=False)
 
         return amplitudes
 
-    def _extract_single_amplitude(
-        self,
-        large_window: obspy.Stream,
-        pick: sbu.Pick,
-        sub_inv: obspy.Inventory,
-        mean: bool = True,
-    ):
-        # normalize window
-        large_window.detrend("linear")
-        if sub_inv is not None:
-            # Remove response and simulate Wood-Anderson
-            try:
-                large_window.remove_response(sub_inv, **self.response_removal_args)
-            except Exception:  # No response information
-                return np.nan
-            large_window.simulate(paz_simulate=WOOD_ANDERSON)
-        elif self.raw_highpass is not None:
-            # Use raw counts and high-pass filter
-            large_window.taper(max_percentage=0.05, type="cosine")
-            large_window.filter(
-                "highpass", freq=self.raw_highpass, corners=4, zerophase=True
-            )
-        else:
-            pass
+    @staticmethod
+    def _as_arrays(prepared: obspy.Stream, taper_len: float) -> list[tuple]:
+        """Flatten a stream to plain arrays once, so the per-pick path is numpy
+        only.
 
-        # Slice window
-        window = large_window.slice(
-            pick.peak_time - self.time_before,
-            pick.peak_time + self.time_after,
-        )
+        Profiling showed amplitude extraction was still the largest stage after
+        the deconvolution was hoisted - 3.4-4.1 ms per pick for what should be a
+        slice and a maximum. The cost was obspy: `Stream.slice` per pick, and a
+        `select()` scan per trace per pick to find the taper bounds. Both are
+        loop-invariant, so they are done once here.
+        """
+        out = []
+        for tr in prepared:
+            if len(tr.data) == 0:
+                continue
+            start = tr.stats.starttime.timestamp
+            out.append((
+                tr.id[-1],                       # component
+                tr.data,
+                start,
+                float(tr.stats.sampling_rate),
+                start + taper_len,               # first trustworthy sample
+                tr.stats.endtime.timestamp - taper_len,
+            ))
+        return out
+
+    def _peak_from_arrays(self, arrays: list[tuple], pick: sbu.Pick, mean: bool):
+        """Peak amplitude in one pick's window. Pure index arithmetic."""
+        t0 = pick.peak_time.timestamp - self.time_before
+        t1 = pick.peak_time.timestamp + self.time_after
+
+        peaks: dict[str, float] = {}
+        for comp, data, start, rate, core_start, core_end in arrays:
+            # Reject rather than measure inside a taper: the signal is driven
+            # smoothly to zero there, so a measurement is wrong, not imprecise.
+            if t0 < core_start or t1 > core_end:
+                continue
+            i0 = int(round((t0 - start) * rate))
+            i1 = int(round((t1 - start) * rate)) + 1
+            if i0 < 0 or i1 > len(data) or i1 <= i0:
+                continue
+            val = float(np.max(np.abs(data[i0:i1])))
+            peaks[comp] = max(peaks.get(comp, 0.0), val)
+
+        if not peaks:
+            return np.nan
+        values = list(peaks.values())
+        return float(np.mean(values) if mean else np.max(values))
+
+    def _peak_in_window(
+        self,
+        prepared: obspy.Stream,
+        pick: sbu.Pick,
+        mean: bool = True,
+        taper_len: float = 0.0,
+    ):
+        """Peak amplitude in one pick's measurement window, cut from an already
+        detrended, deconvolved (or filtered) stream.
+
+        Picks whose window overlaps a taper are returned as NaN rather than
+        measured. The taper drives the signal smoothly to zero, so measuring
+        inside it yields an amplitude that is not merely imprecise but wrong -
+        by up to 200x for a pick at a trace edge. Missing is honest; suppressed
+        is not. This costs about 0.1% of picks on a day-long trace, at the day
+        boundaries and beside gaps.
+        """
+        t_start = pick.peak_time - self.time_before
+        t_end = pick.peak_time + self.time_after
+        window = prepared.slice(t_start, t_end)
 
         if len(window) == 0:
             return np.nan
@@ -211,10 +307,22 @@ class AmplitudeExtractor:
         # Extract peak
         component_peaks = defaultdict(lambda: 0)
         for trace in window:
+            if len(trace.data) == 0:
+                # A slice across a gap yields empty traces; np.max would raise.
+                continue
+            source = prepared.select(id=trace.id)
+            if taper_len > 0 and source:
+                core_start = min(tr.stats.starttime for tr in source) + taper_len
+                core_end = max(tr.stats.endtime for tr in source) - taper_len
+                if t_start < core_start or t_end > core_end:
+                    continue
             val = np.max(
                 np.abs(trace.data)
-            )  # Has been detrended with comparison to larger window before
+            )  # detrended and deconvolved over the whole stream beforehand
             component_peaks[trace.id[-1]] = max(component_peaks[trace.id[-1]], val)
+
+        if not component_peaks:
+            return np.nan
 
         if mean:
             return np.nanmean(list(component_peaks.values()))


### PR DESCRIPTION
Split out of #27 so it can be reviewed and merged on its own. **Two files, +210/-102.** Nothing here depends on SkyPilot — it applies equally to the Fargate path.

## The bug

`extract_amplitudes` called `remove_response` for **every pick** — roughly 6,700 deconvolutions for one busy station-day, each recomputing the same transfer function on a 33 s window.

Hoisting it out of the loop is 5.3× faster, but **correctness is the reason to do it**.

For the pick at `2019-07-06T03:16:17` on `CI.CLC`, the old code returned **0.170**, while every other deconvolution window converges on **0.00045**:

| window | peak |
|---|--:|
| old, `-13/+20 s` | **0.170185** |
| symmetric 33 s | 0.000474 |
| same shape, doubled | 0.000631 |
| 300 s | 0.000445 |
| 3600 s | 0.000445 |

Shifting the window by a fraction of a second moved the answer **380×**. About **5% of picks** were affected. This is the same failure as [Denolle-Lab/cascadia_obs_ensemble#19](https://github.com/Denolle-Lab/cascadia_obs_ensemble/issues/19): a short deconvolution window is not a measurement.

## Verification

508 real picks, `CI.CLC`, the Ridgecrest hour:

- median ratio to the previous implementation **1.0001** (+0.0001 ML)
- **94.3%** within 5%
- the disagreements are exactly the ill-conditioned cases, where the new value is the correct one

## Supporting changes

- **Taper in seconds** (default 60), not obspy's 5% — which on a day-long trace is **72 minutes at each end** and would silently null every pick near a day boundary.
- **Picks inside a taper return NaN.** The taper drives the signal to zero, so a measurement there is wrong rather than imprecise — a pick at a trace edge measured **200× low**. Missing is honest; suppressed is not. Costs ~0.1% of picks.
- **Per-pick path moved to numpy.** `Stream.slice()` per pick over an 8.6M-sample trace, plus a `select()` scan per trace per pick, were both loop-invariant.
- **joblib removed.** `Parallel(n_jobs=-1)` ran *inside* each worker process, oversubscribing every core. `parallel` is accepted and ignored so call sites keep working.

## Why it matters beyond the speedup

Profiling a real shard showed amplitude extraction is the **largest stage in the pipeline — larger than inference**, at 47% of a station-day. It is also the part added since the 2025 campaign.

Based on `rerun-2026-prep` (#26) because the IASPEI Wood-Anderson constants land there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)