### PR TITLE
Hourly AWS cost and activity alerts

### DIFF
--- a/.github/workflows/aws-watch.yml
+++ b/.github/workflows/aws-watch.yml
@@ -1,0 +1,139 @@
+name: AWS activity watch
+
+# Hourly report of what is running on AWS, what it costs, and how to stop it.
+#
+# Cost Explorer lags about a day, which is too slow to catch the three ways a
+# Spot campaign quietly overspends: an instance left up, a jobs controller that
+# outlives its jobs, and a managed job silently satisfied on-demand at ~3x the
+# Spot price. This runs in CI rather than on a laptop so it keeps watching when
+# the laptop is closed.
+#
+# Notification model: ONE issue is kept as the live dashboard. Its body is
+# rewritten every hour, which is silent. A comment - which does email everyone
+# subscribed - is posted only when the state CHANGES (idle -> running, or new
+# warnings). Otherwise an hourly job would train you to ignore it.
+#
+# Setup: see docs/rerun_2026/15_monitoring.md. Needs either
+#   - AWS_WATCH_ROLE_ARN (preferred; GitHub OIDC, no stored keys), or
+#   - AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY secrets (read-only IAM user).
+
+on:
+  schedule:
+    - cron: "7 * * * *"      # hourly, off the hour to avoid the cron stampede
+  workflow_dispatch:          # and on demand, for "what is running right now?"
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write             # required for OIDC
+
+concurrency:
+  group: aws-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - run: pip install --quiet boto3
+
+      # Prefer OIDC: no long-lived credentials in the repo at all.
+      - name: Configure AWS (OIDC)
+        if: vars.AWS_WATCH_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_WATCH_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Configure AWS (access keys)
+        if: vars.AWS_WATCH_ROLE_ARN == ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Scan
+        id: scan
+        run: |
+          python scripts/aws_watch.py --format markdown > report.md || true
+          # Running or not decides whether this is an alert or an all-clear.
+          if grep -q "No instances running" report.md; then
+            echo "running=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "running=true" >> "$GITHUB_OUTPUT"
+          fi
+          if grep -q "^### Warnings" report.md; then
+            echo "warned=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "warned=false" >> "$GITHUB_OUTPUT"
+          fi
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update the dashboard issue
+        uses: actions/github-script@v7
+        env:
+          RUNNING: ${{ steps.scan.outputs.running }}
+          WARNED: ${{ steps.scan.outputs.warned }}
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('report.md', 'utf8');
+            const running = process.env.RUNNING === 'true';
+            const warned = process.env.WARNED === 'true';
+            const TITLE = 'AWS activity dashboard';
+            const LABEL = 'aws-watch';
+
+            const found = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue label:${LABEL}`,
+            });
+            let issue = found.data.items[0];
+
+            const stamp = new Date().toISOString();
+            const full = `${body}\n\n---\n_Updated ${stamp} by ` +
+              `[aws-watch](../actions/workflows/aws-watch.yml). ` +
+              `Run it on demand from the Actions tab._`;
+
+            if (!issue) {
+              if (!running) return;               // nothing to report, no issue yet
+              issue = (await github.rest.issues.create({
+                ...context.repo, title: TITLE, body: full, labels: [LABEL],
+              })).data;
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: ':rotating_light: AWS resources are running. Details in the issue body.',
+              });
+              return;
+            }
+
+            // Body updates are silent; comments notify. Only comment on a
+            // state change, so an hourly job does not become background noise.
+            const wasRunning = !/No instances running/.test(issue.body || '');
+            const wasWarned = /^### Warnings/m.test(issue.body || '');
+            await github.rest.issues.update({
+              ...context.repo, issue_number: issue.number, body: full,
+              state: running ? 'open' : 'closed',
+            });
+
+            if (running && !wasRunning) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: ':rotating_light: **AWS resources started running.**\n\n' + body,
+              });
+            } else if (running && warned && !wasWarned) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: ':warning: **New warning from the AWS watch.**\n\n' + body,
+              });
+            } else if (!running && wasRunning) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: ':white_check_mark: All AWS resources are stopped. Closing.',
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -42,8 +42,59 @@ pixi run smoke-test
 | [docs/rerun_2026/README.md](docs/rerun_2026/README.md) | Production runbook |
 | [docs/phasenet_v7_model_description.md](docs/phasenet_v7_model_description.md) | Model architecture & benchmarks |
 | [docs/smoke_test_workflow.md](docs/smoke_test_workflow.md) | Validation workflow |
+| [docs/rerun_2026/15_monitoring.md](docs/rerun_2026/15_monitoring.md) | Cost alerts and emergency stop |
 | [reports/](reports/) | Rendered benchmark reports, published at [seisscoped.org/QuakeScope](https://seisscoped.org/QuakeScope/) |
 | [SECURITY_AUDIT.md](SECURITY_AUDIT.md) | Security assessment |
+
+## Cost monitoring
+
+Campaigns run on Spot instances that are easy to leave running. Two layers watch
+for that; neither is on by default.
+
+**What is running right now**, from your laptop:
+
+```bash
+pixi run -e cloud watch      # instances, spot vs on-demand, $/hr, $/month
+```
+
+Read-only, and it prints the stop commands for whatever it finds.
+
+**Hourly alerts by email**, via GitHub Actions
+([`.github/workflows/aws-watch.yml`](.github/workflows/aws-watch.yml)). Three
+things must all be true, and none is automatic:
+
+1. **The workflow must be on the default branch.** GitHub runs `schedule:`
+   triggers *only* from the default branch; on a feature branch it never fires.
+2. **Credentials must be set** — repository variable `AWS_WATCH_ROLE_ARN` (OIDC,
+   preferred, no stored keys) or the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+   secrets. The IAM policy is describe-only.
+3. **You must watch the repo**, since the alert is an issue comment and GitHub
+   turns that into email.
+
+Test it without waiting an hour:
+
+```bash
+gh workflow run aws-watch.yml
+```
+
+It does **not** email hourly. One issue is the dashboard, its body updates
+silently, and a comment — which notifies — is posted only when the state
+changes: idle → running, a new warning, or all-clear.
+
+**Turning it off**, at the level you want:
+
+```bash
+gh workflow disable aws-watch.yml     # stop entirely (enable to resume)
+```
+
+To keep the dashboard but stop the email, unsubscribe from that one issue. To
+silence all repo email, set the repo to *Participating and @mentions*. To pause,
+drop the `schedule:` block and keep `workflow_dispatch`.
+
+Add an **AWS Budgets** daily alert as an independent backstop — it fires even if
+Actions, the credentials, or the repo are broken. Setup, the IAM policy and the
+emergency-stop sequence are in
+[docs/rerun_2026/15_monitoring.md](docs/rerun_2026/15_monitoring.md).
 
 ## Key Features
 

--- a/docs/rerun_2026/15_monitoring.md
+++ b/docs/rerun_2026/15_monitoring.md
@@ -1,0 +1,189 @@
+# 15 — Knowing what is running, and stopping it fast
+
+Cost Explorer lags about a day. That is too slow to catch the three ways a Spot
+campaign quietly overspends:
+
+1. an instance left running after a test,
+2. a SkyPilot **jobs controller** that outlives the jobs it managed,
+3. a managed job silently satisfied **on-demand** at roughly 3× the Spot price —
+   which happened during the v3 smoke test and was visible only as
+   `InstanceLifecycle` in the EC2 console.
+
+Two independent layers cover this: an hourly report you read, and an AWS-native
+budget alarm that fires even if the first one breaks.
+
+## Layer 1 — hourly report (GitHub Actions)
+
+`.github/workflows/aws-watch.yml` runs `scripts/aws_watch.py` every hour across
+us-west-2, us-east-1 and us-east-2 and reports:
+
+- every running instance, its type, **spot vs on-demand**, and age
+- hourly burn at the *current* spot price for that type and AZ
+- the projection to $/day and $/month if nothing changes
+- open spot requests, which can relaunch instances you just terminated
+- ready-to-paste emergency-stop commands, in the right order
+
+It is read-only and changes nothing in the account.
+
+**Notification model.** One issue, labelled `aws-watch`, is the live dashboard.
+Its body is rewritten hourly, which is silent. A *comment* — which emails
+everyone subscribed to the repo — is posted only when the state **changes**:
+idle → running, a new warning appears, or everything stops. An hourly job that
+notified every hour would train you to ignore it.
+
+That gives you email out of the box, since GitHub emails issue activity. For
+push notifications, the GitHub mobile app covers the same events; for WhatsApp
+or Slack, add a step to the workflow posting the same `report.md` to a webhook.
+
+### Setup
+
+Preferred, no stored credentials — GitHub OIDC:
+
+1. Create an IAM role trusting `token.actions.githubusercontent.com`, scoped to
+   this repo, with the read-only policy below.
+2. Set repository **variable** `AWS_WATCH_ROLE_ARN` to its ARN.
+
+Fallback, if OIDC is not set up: create a read-only IAM user and set repository
+**secrets** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. The workflow picks
+whichever is configured.
+
+Minimum policy — describe-only, no ability to launch or terminate anything:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "ec2:DescribeInstances",
+      "ec2:DescribeSpotInstanceRequests",
+      "ec2:DescribeSpotPriceHistory",
+      "pricing:GetProducts"
+    ],
+    "Resource": "*"
+  }]
+}
+```
+
+Deliberately read-only: a monitor that can stop things is a monitor that can
+stop the wrong thing. Stopping stays a human action.
+
+### Turning it on
+
+Three things must all be true, and none of them is automatic:
+
+1. **`aws-watch.yml` must be on the default branch.** GitHub runs `schedule:`
+   triggers *only* from the default branch. On a feature branch the file is
+   inert — it will not fire once, ever. (Push-triggered workflows are different
+   and do run from any branch, which is why `pages.yml` worked from
+   `rerun-2026-prep`.)
+2. **Credentials must be configured** — repository variable
+   `AWS_WATCH_ROLE_ARN`, or the two access-key secrets. Without either, every
+   run fails on the first AWS call.
+3. **You must be watching the repo**, so issue comments become email. Check at
+   *Watch → All Activity*, or:
+
+```bash
+gh api repos/SeisSCOPED/QuakeScope/subscription -q .subscribed
+```
+
+Verify it works without waiting an hour — run it by hand:
+
+```bash
+gh workflow run aws-watch.yml
+gh run list --workflow aws-watch.yml --limit 3
+```
+
+### Turning it off
+
+Pick the level that matches what you actually want to stop.
+
+**Stop the checks entirely** (no runs, no issue updates, no email):
+
+```bash
+gh workflow disable aws-watch.yml     # re-enable with: gh workflow enable
+```
+
+Or in the browser: **Actions → AWS activity watch → ⋯ → Disable workflow**.
+
+**Keep the dashboard, stop the email.** The issue body still updates hourly so
+you can look when you want, but comments stop reaching your inbox — unsubscribe
+from that one issue (*Unsubscribe* in the right-hand sidebar), or:
+
+```bash
+gh api -X PUT repos/SeisSCOPED/QuakeScope/issues/<n>/subscription -f ignored=true
+```
+
+**Stop all repo email but keep everything running:** set the repo to
+*Participating and @mentions* instead of *All Activity*. You will then only be
+emailed if the bot @-mentions you, which it does not — so this effectively
+silences it while leaving the dashboard live.
+
+**Pause without disabling:** delete the `schedule:` block and keep
+`workflow_dispatch:`. The workflow then only runs when you ask it to.
+
+Two things worth knowing:
+
+- **GitHub auto-disables scheduled workflows after 60 days without repo
+  activity**, and emails the repo admins when it does. If the alerts go quiet
+  during a long gap, check whether this happened rather than assuming all is
+  well.
+- Disabling the workflow disables the *watching*, not the *spending*. Nothing
+  about turning alerts off stops an instance.
+
+### Running it yourself
+
+```bash
+pixi run -e cloud watch            # what is running right now
+pixi run -e cloud watch-md         # markdown, same as the issue
+python scripts/aws_watch.py --quiet # silent when idle, for a local cron
+```
+
+## Layer 2 — AWS Budgets (the backstop)
+
+The workflow depends on GitHub Actions, credentials, and the repo. Budgets does
+not. Set one up so a runaway campaign is caught even if layer 1 is broken:
+
+**Billing → Budgets → Create budget → Cost budget**, monthly, with alerts at
+50/80/100% of a figure you would be unhappy to exceed, emailing you. Add a
+second **daily** budget at a low threshold — a daily alarm catches a runaway in
+hours rather than at month end, which is the whole point.
+
+Budgets alerts on spend, not on instances, so it lags a few hours — hence both
+layers.
+
+## Emergency stop
+
+Terminate, do not stop: a stopped instance still bills its EBS volume and
+still counts as a leak.
+
+```bash
+# what is running, with the exact stop commands for whatever it finds
+pixi run -e cloud watch
+```
+
+From the console:
+
+1. Set the region — nothing stops in the wrong region, and a campaign may span
+   several.
+2. **EC2 → Instances**, clear the default *Running* filter so terminated
+   instances are visible too, select, *Instance state → Terminate*.
+3. **EC2 → Spot Requests** → cancel any `open`/`active`. Cancelling a request
+   does **not** terminate its instance, and a persistent request will relaunch
+   one, so do both.
+4. Verify **Instances** filtered to *Running* is empty.
+
+> Whatever orchestrator you use, check afterwards rather than trusting the
+> teardown command. `aws_watch.py` queries EC2 directly, which is the only
+> account of what is actually running.
+
+## Known standing resources
+
+The first run of this watcher found, in us-east-2:
+
+- `niyiyu-quakescope-web-service` (`t2.large`, on-demand) running **11,210 hours**
+  — about 467 days, ~$67/month, on the order of $1,000 to date. Not part of any
+  campaign. Left alone because it may be a live service, but it is exactly the
+  kind of thing this exists to surface.
+- Batch compute environments `niyiyu_earthscope` and `pickblue_OBS`, still
+  `ENABLED`. Idle and therefore free, but they will accept jobs.

--- a/pixi.toml
+++ b/pixi.toml
@@ -54,6 +54,8 @@ cloud = ["cpu"]
 dev = ["cpu", "dev"]
 
 [tasks]
+watch = "python scripts/aws_watch.py"
+watch-md = "python scripts/aws_watch.py --format markdown"
 smoke-test = "jupyter notebook tutorials/phasenet_smoke_test_ridgecrest.ipynb"
 compare-models = "jupyter notebook tutorials/compare_phasenet_models.ipynb"
 lab = "jupyter lab"

--- a/scripts/aws_watch.py
+++ b/scripts/aws_watch.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""
+What is running on AWS right now, what it is costing, and how to stop it.
+
+Written because a Spot campaign can quietly cost money in three ways that none
+of the usual dashboards make obvious within an hour: an instance that should
+have been torn down, a SkyPilot jobs controller that outlives its jobs, and a
+managed job silently satisfied on-demand at ~3x the Spot price. Cost Explorer
+lags about a day, which is too slow to catch any of them.
+
+Reports, per region:
+  * every instance running, its type, lifecycle (spot vs on-demand), and age
+  * the hourly burn at the CURRENT spot price for that type and AZ
+  * what that projects to per day and per month if nothing changes
+  * anything that looks wrong: on-demand where Spot was intended, an idle
+    jobs controller, an instance running longer than a campaign shard should
+
+Read-only: it makes no changes to the account. Emergency-stop commands are
+printed for a human to run, deliberately not executed.
+
+    python scripts/aws_watch.py                    # human-readable
+    python scripts/aws_watch.py --format markdown  # for a GitHub issue
+    python scripts/aws_watch.py --quiet            # print nothing when idle
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from collections import defaultdict
+
+import boto3
+from botocore.exceptions import ClientError
+
+DEFAULT_REGIONS = ["us-west-2", "us-east-1", "us-east-2"]
+
+# An instance older than this is worth a second look: campaign shards are sized
+# in hours, and a controller left up is the classic way to leak money.
+STALE_HOURS = 12.0
+
+
+def _now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def spot_price(ec2, instance_type: str, az: str) -> float | None:
+    """Current spot price for a type in an AZ. None if unavailable."""
+    try:
+        r = ec2.describe_spot_price_history(
+            InstanceTypes=[instance_type],
+            ProductDescriptions=["Linux/UNIX"],
+            AvailabilityZone=az,
+            MaxResults=1,
+        )
+        hist = r.get("SpotPriceHistory", [])
+        return float(hist[0]["SpotPrice"]) if hist else None
+    except ClientError:
+        return None
+
+
+def on_demand_price(instance_type: str, region: str) -> float | None:
+    """On-demand list price. The pricing API lives only in a few regions."""
+    location = {
+        "us-west-2": "US West (Oregon)",
+        "us-east-1": "US East (N. Virginia)",
+        "us-east-2": "US East (Ohio)",
+    }.get(region)
+    if not location:
+        return None
+    try:
+        pricing = boto3.client("pricing", region_name="us-east-1")
+        r = pricing.get_products(
+            ServiceCode="AmazonEC2",
+            Filters=[
+                {"Type": "TERM_MATCH", "Field": "instanceType", "Value": instance_type},
+                {"Type": "TERM_MATCH", "Field": "location", "Value": location},
+                {"Type": "TERM_MATCH", "Field": "operatingSystem", "Value": "Linux"},
+                {"Type": "TERM_MATCH", "Field": "tenancy", "Value": "Shared"},
+                {"Type": "TERM_MATCH", "Field": "preInstalledSw", "Value": "NA"},
+                {"Type": "TERM_MATCH", "Field": "capacitystatus", "Value": "Used"},
+            ],
+            MaxResults=1,
+        )
+        if not r["PriceList"]:
+            return None
+        p = json.loads(r["PriceList"][0])
+        term = list(p["terms"]["OnDemand"].values())[0]
+        dim = list(term["priceDimensions"].values())[0]
+        return float(dim["pricePerUnit"]["USD"])
+    except Exception:
+        return None
+
+
+def scan_region(region: str) -> dict:
+    ec2 = boto3.client("ec2", region_name=region)
+    try:
+        pages = ec2.get_paginator("describe_instances").paginate(
+            Filters=[{"Name": "instance-state-name",
+                      "Values": ["pending", "running", "stopping"]}]
+        )
+        instances = [i for p in pages for r in p["Reservations"] for i in r["Instances"]]
+    except ClientError as exc:
+        return {"region": region, "error": str(exc)[:120], "instances": [],
+                "hourly": 0.0, "warnings": []}
+
+    rows, warnings, hourly = [], [], 0.0
+    for inst in instances:
+        tags = {t["Key"]: t["Value"] for t in inst.get("Tags", [])}
+        name = tags.get("Name", "")
+        cluster = tags.get("skypilot-cluster-name", "")
+        itype = inst["InstanceType"]
+        az = inst["Placement"]["AvailabilityZone"]
+        is_spot = inst.get("InstanceLifecycle") == "spot"
+        age_h = (_now() - inst["LaunchTime"]).total_seconds() / 3600
+
+        price = spot_price(ec2, itype, az) if is_spot else on_demand_price(itype, region)
+        hourly += price or 0.0
+
+        rows.append({
+            "id": inst["InstanceId"], "type": itype, "az": az,
+            "lifecycle": "spot" if is_spot else "on-demand",
+            "age_h": age_h, "price": price, "name": name,
+            "cluster": cluster, "state": inst["State"]["Name"],
+        })
+
+        # The three ways a Spot campaign quietly costs more than intended.
+        if cluster and not is_spot:
+            warnings.append(
+                f"{inst['InstanceId']} ({name or itype}) is ON-DEMAND but is a "
+                f"SkyPilot instance - roughly 3x the Spot price"
+            )
+        if "jobs-controller" in name and age_h > STALE_HOURS:
+            warnings.append(
+                f"{inst['InstanceId']} is a jobs controller up for {age_h:.1f} h - "
+                f"controllers outlive their jobs and are easy to forget"
+            )
+        elif age_h > STALE_HOURS and not name.startswith("sky-jobs-controller"):
+            warnings.append(
+                f"{inst['InstanceId']} ({name or itype}) has run {age_h:.1f} h"
+            )
+
+    return {"region": region, "instances": rows, "hourly": hourly,
+            "warnings": warnings, "error": None}
+
+
+def scan_spot_requests(region: str) -> int:
+    """Open/active requests can relaunch after you terminate an instance."""
+    try:
+        ec2 = boto3.client("ec2", region_name=region)
+        r = ec2.describe_spot_instance_requests(
+            Filters=[{"Name": "state", "Values": ["open", "active"]}]
+        )
+        return len(r.get("SpotInstanceRequests", []))
+    except ClientError:
+        return 0
+
+
+def render(results: list[dict], spot_open: dict, fmt: str) -> str:
+    total_hourly = sum(r["hourly"] for r in results)
+    n = sum(len(r["instances"]) for r in results)
+    warnings = [(r["region"], w) for r in results for w in r["warnings"]]
+    md = fmt == "markdown"
+    L: list[str] = []
+    h1 = "## " if md else ""
+
+    if n == 0:
+        L.append(f"{h1}No instances running")
+        L.append("")
+        L.append(f"Checked {', '.join(r['region'] for r in results)} at "
+                 f"{_now():%Y-%m-%d %H:%M} UTC. Nothing is costing compute.")
+        leftover = {k: v for k, v in spot_open.items() if v}
+        if leftover:
+            L.append("")
+            L.append(f"But {sum(leftover.values())} spot request(s) are still open "
+                     f"in {', '.join(leftover)} - these can relaunch instances.")
+        return "\n".join(L)
+
+    L.append(f"{h1}{n} instance(s) running - ${total_hourly:.4f}/hour")
+    L.append("")
+    L.append(f"**${total_hourly * 24:.2f}/day, ${total_hourly * 24 * 30:,.0f}/month** "
+             f"if nothing changes. Checked {_now():%Y-%m-%d %H:%M} UTC.")
+    L.append("")
+
+    if warnings:
+        L.append(f"{'### ' if md else ''}Warnings")
+        L.append("")
+        for region, w in warnings:
+            L.append(f"- **{region}**: {w}" if md else f"  ! {region}: {w}")
+        L.append("")
+
+    if md:
+        L.append("| region | instance | type | lifecycle | age | $/hr | name |")
+        L.append("|---|---|---|---|--:|--:|---|")
+    for r in results:
+        for i in r["instances"]:
+            price = f"{i['price']:.4f}" if i["price"] is not None else "?"
+            if md:
+                L.append(f"| {r['region']} | `{i['id']}` | {i['type']} | "
+                         f"{i['lifecycle']} | {i['age_h']:.1f} h | {price} | "
+                         f"{i['name'] or '-'} |")
+            else:
+                L.append(f"  {r['region']:11s} {i['id']:20s} {i['type']:14s} "
+                         f"{i['lifecycle']:10s} {i['age_h']:6.1f}h  ${price:>8s}  "
+                         f"{i['name']}")
+    L.append("")
+
+    open_total = sum(spot_open.values())
+    if open_total:
+        L.append(f"{open_total} open spot request(s): "
+                 + ", ".join(f"{k} ({v})" for k, v in spot_open.items() if v))
+        L.append("")
+
+    L.append(f"{'### ' if md else ''}Emergency stop")
+    L.append("")
+    L.append("Kill the jobs controller **first** - its job is relaunching preempted "
+             "workers, so it will resurrect anything you terminate.")
+    L.append("")
+    L.append("```bash")
+    L.append("sky jobs cancel --all && sky down --all      # preferred")
+    L.append("")
+    for r in results:
+        if r["instances"]:
+            ids = " ".join(i["id"] for i in r["instances"]
+                           if "jobs-controller" in i["name"])
+            rest = " ".join(i["id"] for i in r["instances"]
+                            if "jobs-controller" not in i["name"])
+            if ids:
+                L.append(f"aws ec2 terminate-instances --region {r['region']} "
+                         f"--instance-ids {ids}   # controller first")
+            if rest:
+                L.append(f"aws ec2 terminate-instances --region {r['region']} "
+                         f"--instance-ids {rest}")
+    L.append("```")
+    return "\n".join(L)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--regions", default=",".join(DEFAULT_REGIONS))
+    ap.add_argument("--format", choices=["text", "markdown"], default="text")
+    ap.add_argument("--quiet", action="store_true",
+                    help="Print nothing when nothing is running")
+    ap.add_argument("--fail-if-running", action="store_true",
+                    help="Exit 1 when anything is running (for CI gating)")
+    args = ap.parse_args(argv)
+
+    regions = [r.strip() for r in args.regions.split(",") if r.strip()]
+    results = [scan_region(r) for r in regions]
+    spot_open = {r: scan_spot_requests(r) for r in regions}
+    n = sum(len(r["instances"]) for r in results)
+
+    if n == 0 and args.quiet:
+        return 0
+    print(render(results, spot_open, args.format))
+    for r in results:
+        if r["error"]:
+            print(f"\n! {r['region']}: {r['error']}", file=sys.stderr)
+    return 1 if (n and args.fail_if_running) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Split out of #27. **Independent of the deployment platform** — useful whether campaigns run on Fargate or SkyPilot. Touches no pipeline code.

## Why

Cost Explorer lags about a day. That is too slow to catch an instance left running after a test, or a job silently satisfied **on-demand at ~3× the Spot price** — which happened during a v3 smoke test and was visible only as `InstanceLifecycle` in the EC2 console.

## What it reports

`scripts/aws_watch.py` scans us-west-2, us-east-1 and us-east-2:

- every running instance, its type, **spot vs on-demand**, and age
- hourly burn at the *current* spot price for that type and AZ
- the $/day and $/month projection
- open spot requests, which can relaunch an instance you just terminated
- ready-to-paste stop commands for whatever it found

**Read-only by design.** A monitor that can terminate things can terminate the wrong things; stopping stays a human action.

```bash
pixi run -e cloud watch
```

## Notification model

One issue, labelled `aws-watch`, is the live dashboard. Its body is rewritten hourly, which is **silent**. A *comment* — which emails subscribers — is posted only when the state **changes**: idle → running, a new warning, or all-clear. An hourly job that notified hourly would train you to ignore it.

## Three conditions, none automatic

This is documented prominently because the workflow will otherwise look installed and do nothing:

1. **The workflow must be on the default branch.** GitHub runs `schedule:` triggers *only* from there — on a feature branch it never fires once.
2. **Credentials must be set** — `AWS_WATCH_ROLE_ARN` (OIDC, no stored keys) or the two access-key secrets. The IAM policy is describe-only.
3. **You must be watching the repo**, since the alert is an issue comment.

Test without waiting an hour: `gh workflow run aws-watch.yml`.

Turning it off has four levels — disable the workflow, unsubscribe from the issue, drop the repo to *Participating*, or remove the `schedule:` — all in [15_monitoring.md](docs/rerun_2026/15_monitoring.md). It also notes that GitHub auto-disables scheduled workflows after 60 days of repo inactivity, which otherwise looks identical to a quiet account.

Recommends an **AWS Budgets** daily alarm as an independent backstop that fires even if Actions, the credentials, or the repo break.

## It already found something

The first run: `niyiyu-quakescope-web-service`, a `t2.large` in us-east-2, running **11,210 hours — about 467 days**, ~$67/month, on the order of **$1,000 to date**. Not part of any campaign. Left alone in case it is a live service, but recorded in the doc.

Based on `rerun-2026-prep` (#26) because it edits the README that PR also changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)